### PR TITLE
Fix bug with roles in registration (Closes #52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Bumped requests from 2.19.1 to 2.21.0 in /frontend
 - Bumped PyYAML from 3.13 to 4.2b4 in /frontend
 - Bumped PyYAML from 3.13 to 4.2b4 in /backend
+- Resolved bug with user roles on registration process
 
 ## [1.0.0] - 2018-12-20
 ### Added (initial Apollo release)

--- a/frontend/webapp/core/__init__.py
+++ b/frontend/webapp/core/__init__.py
@@ -161,8 +161,11 @@ def get_timezone():
 
 @user_registered.connect_via(app)
 def on_user_registered(app, user, confirm_token):
-    default_role = data_store.find_role("pending")
-    data_store.add_role_to_user(user, default_role)
+    user_ = data_store.find_role("user")
+    data_store.remove_role_from_user(user, user_)
+
+    pending_ = data_store.find_role("pending")
+    data_store.add_role_to_user(user, pending_)
     db.session.commit()
 
 


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
Resolving issue with roles on registration process (https://github.com/FORTH-ICS-INSPIRE/artemis/issues/52)

What component(s) does this PR affect?

- [ ] Back-End (Database, Microservices, Containers, etc)
- [x] Front-End (Flask, API, etc)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Microservices, Containers, etc)
- [ ] Front-End (Flask, API, etc)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
#52 
### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->

### Type
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [x] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [x] This change requires a change in the documentation.
- [x] I have updated the documentation accordingly.