### PR TITLE
Build latest container for GCC (Closes #77)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Dimitrios Mavrommatis <jim.mavrommatis@gmail.com>"
 
 WORKDIR /root
 
-RUN apk add --update openssl && \
+RUN apk add --no-cache openssl && \
     wget https://dl.google.com/closure-compiler/compiler-latest.tar.gz && \
     tar -xzvf compiler-latest.tar.gz
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,12 @@
-FROM femtopixel/google-closure-compiler:0.1.5 as builder
+FROM java:openjdk-8-jre-alpine as builder
 LABEL maintainer="Dimitrios Mavrommatis <jim.mavrommatis@gmail.com>"
 
 WORKDIR /root
+
+RUN apk add --update openssl && \
+    wget https://dl.google.com/closure-compiler/compiler-latest.tar.gz && \
+    tar -xzvf compiler-latest.tar.gz
+
 COPY ./webapp/static/js/custom/ /root/
 COPY ./minify-js.sh /root/
 RUN mkdir /root/prod/

--- a/frontend/minify-js.sh
+++ b/frontend/minify-js.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 for filename in ./*.js; do
-    google-closure-compiler --js $filename --js_output_file ./prod/'prod-'$(basename $filename)
+    java -jar closure-compiler-*.jar --js $filename --js_output_file ./prod/'prod-'$(basename $filename)
 done


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->
Builder on the frontend container used a very old version of google's closure compiler so we build it on the fly now.

What component(s) does this PR affect?

- [ ] Back-End (Database, Microservices, Containers, etc)
- [x] Front-End (Flask, API, etc)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Microservices, Containers, etc)
- [ ] Front-End (Flask, API, etc)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
#77

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->

### Type
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [x] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [x] This change requires a change in the documentation.
- [x] I have updated the documentation accordingly.
