### PR TITLE
Auto-clean no-hijack BGP updates (Closes #33)

### DIFF
--- a/.env
+++ b/.env
@@ -18,7 +18,7 @@ SUPERVISOR_PORT=9001
 # Monitor-specific configs
 RIS_ID=8522
 
-# DB connection details (used by all containers)
+# DB details (used by all containers)
 DB_HOST=postgres
 DB_PORT=5432
 DB_NAME=artemis_db

--- a/.env
+++ b/.env
@@ -26,6 +26,9 @@ DB_USER=artemis_user
 DB_PASS=Art3m1s
 DB_SCHEMA=public
 
+DB_AUTOCLEAN=false
+DB_BACKUP=true
+
 # Frontend details
 MACHINE_IP=0.0.0.0
 FLASK_PORT=8000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -122,10 +122,10 @@ services:
             POSTGRES_DB: ${DB_NAME}
             POSTGRES_USER: ${DB_USER}
             POSTGRES_PASSWORD: ${DB_PASS}
+            DB_BACKUP: ${DB_BACKUP}
+            DB_AUTOCLEAN: ${DB_AUTOCLEAN}
         volumes:
             - ./postgres-data-current:/var/lib/postgresql/data
-            - ./other/postgres-backup.sh:/etc/periodic/daily/backup
-            - ./other/postgres-cleanup.sh:/etc/periodic/hourly/cleanup
             - ./other/postgres-entrypoint.sh:/postgres-entrypoint.sh
             - ./postgres-data-backup/:/tmp/
             - ./other/db/init.sql:/docker-entrypoint-initdb.d/zinit.sql

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -125,10 +125,13 @@ services:
         volumes:
             - ./postgres-data-current:/var/lib/postgresql/data
             - ./other/postgres-backup.sh:/etc/periodic/daily/backup
+            - ./other/postgres-cleanup.sh:/etc/periodic/hourly/cleanup
+            - ./other/postgres-entrypoint.sh:/postgres-entrypoint.sh
             - ./postgres-data-backup/:/tmp/
             - ./other/db/init.sql:/docker-entrypoint-initdb.d/zinit.sql
             - ./other/db/data/:/docker-entrypoint-initdb.d/data/
             - ./other/db/libs/:/docker-entrypoint-initdb.d/libs/
+        entrypoint: ["./postgres-entrypoint.sh"]
     postgrest:
         image: postgrest/postgrest:v5.2.0
         container_name: postgrest

--- a/other/postgres-backup.sh
+++ b/other/postgres-backup.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-pg_dump -d $POSTGRES_DB -U $POSTGRES_USER -F t -f /tmp/db.tar > /tmp/db.log 2>&1

--- a/other/postgres-backup.sh
+++ b/other/postgres-backup.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-pg_dump -d artemis_db -U artemis_user -F t -f /tmp/db.tar > /tmp/db.log 2>&1
+pg_dump -d $POSTGRES_DB -U $POSTGRES_USER -F t -f /tmp/db.tar > /tmp/db.log 2>&1

--- a/other/postgres-cleanup.sh
+++ b/other/postgres-cleanup.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-psql -d $POSTGRES_DB -U $POSTGRES_USER -c "DELETE FROM bgp_updates WHERE timestamp < NOW() - interval '1 hours' AND handled=true AND hijack_key=ARRAY[]::text[];"

--- a/other/postgres-cleanup.sh
+++ b/other/postgres-cleanup.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+psql -d $POSTGRES_DB -U $POSTGRES_USER -c "DELETE FROM bgp_updates WHERE timestamp < NOW() - interval '1 hours' AND handled=true AND hijack_key=ARRAY[]::text[];"

--- a/other/postgres-entrypoint.sh
+++ b/other/postgres-entrypoint.sh
@@ -1,2 +1,18 @@
 #!/bin/bash
+
+if [[ "${DB_BACKUP}" == "true" ]]; then
+    cat > /etc/periodic/daily/backup <<EOF
+#!/bin/sh
+pg_dump -d $POSTGRES_DB -U $POSTGRES_USER -F t -f /tmp/db.tar > /tmp/db.log 2>&1
+EOF
+fi
+
+re='^[0-9]+$'
+if [[ $DB_AUTOCLEAN =~ $re ]]; then
+    cat > /etc/periodic/hourly/cleanup <<EOF
+#!/bin/sh
+psql -d $POSTGRES_DB -U $POSTGRES_USER -c "DELETE FROM bgp_updates WHERE timestamp < NOW() - interval '${DB_AUTOCLEAN} hours' AND handled=true AND hijack_key=ARRAY[]::text[];"
+EOF
+fi
+
 crond && docker-entrypoint.sh postgres

--- a/other/postgres-entrypoint.sh
+++ b/other/postgres-entrypoint.sh
@@ -5,6 +5,7 @@ if [[ "${DB_BACKUP}" == "true" ]]; then
 #!/bin/sh
 pg_dump -d $POSTGRES_DB -U $POSTGRES_USER -F t -f /tmp/db.tar > /tmp/db.log 2>&1
 EOF
+    chmod +x /etc/periodic/daily/backup
 fi
 
 re='^[0-9]+$'
@@ -13,6 +14,7 @@ if [[ $DB_AUTOCLEAN =~ $re ]]; then
 #!/bin/sh
 psql -d $POSTGRES_DB -U $POSTGRES_USER -c "DELETE FROM bgp_updates WHERE timestamp < NOW() - interval '${DB_AUTOCLEAN} hours' AND hijack_key=ARRAY[]::text[];"
 EOF
+    chmod +x /etc/periodic/hourly/cleanup
 fi
 
 crond && docker-entrypoint.sh postgres

--- a/other/postgres-entrypoint.sh
+++ b/other/postgres-entrypoint.sh
@@ -11,7 +11,7 @@ re='^[0-9]+$'
 if [[ $DB_AUTOCLEAN =~ $re ]]; then
     cat > /etc/periodic/hourly/cleanup <<EOF
 #!/bin/sh
-psql -d $POSTGRES_DB -U $POSTGRES_USER -c "DELETE FROM bgp_updates WHERE timestamp < NOW() - interval '${DB_AUTOCLEAN} hours' AND handled=true AND hijack_key=ARRAY[]::text[];"
+psql -d $POSTGRES_DB -U $POSTGRES_USER -c "DELETE FROM bgp_updates WHERE timestamp < NOW() - interval '${DB_AUTOCLEAN} hours' AND hijack_key=ARRAY[]::text[];"
 EOF
 fi
 

--- a/other/postgres-entrypoint.sh
+++ b/other/postgres-entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+crond && docker-entrypoint.sh postgres


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->
Changed entrypoint of database's container to start the cron daemon by itself and also we map a new file that cleans all non-hijack BGP updates.

What component(s) does this PR affect?

- [x] Back-End (Database, Microservices, Containers, etc)
- [ ] Front-End (Flask, API, etc)
- [ ] Docs
- [x] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Microservices, Containers, etc)
- [ ] Front-End (Flask, API, etc)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #33

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->

### Type
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [x] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation.
- [ ] I have updated the documentation accordingly.
