### PR TITLE
Switched dumping from config dict to raw_config str (Closes #110)

### DIFF
--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -655,7 +655,7 @@ class Database:
                         comment = config["comment"]
                         del config["comment"]
 
-                    config_hash = hashlib.shake_128(pickle.dumps(config)).hexdigest(16)
+                    config_hash = hashlib.shake_128(pickle.dumps(raw_config)).hexdigest(16)
                     self._save_config(config_hash, config, raw_config, comment)
             except Exception:
                 log.exception("{}".format(config))
@@ -679,7 +679,7 @@ class Database:
                         if "comment" in config:
                             comment = config["comment"]
                             del config["comment"]
-                        config_hash = hashlib.shake_128(pickle.dumps(config)).hexdigest(
+                        config_hash = hashlib.shake_128(pickle.dumps(raw_config)).hexdigest(
                             16
                         )
                         latest_config_in_db_hash = (


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->

What component(s) does this PR affect?

- [x] Back-End (Database, Microservices, Containers, etc)
- [ ] Front-End (Flask, API, etc)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Microservices, Containers, etc)
- [ ] Front-End (Flask, API, etc)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #110 

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->
Switched from dict to string hashing

### Type
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [x] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation.
- [ ] I have updated the documentation accordingly.
