### PR TITLE
Fixing backend behavior when running old containers on newer DBs than intended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [UNRELEASED] (Atlas) - YYYY-MM-DD
 ### Added
-- TBD (Added a new feature)
 - Tooltip support for peers seen BGP Announcement/Withdrawal on hijack view.
 - Support for rfc2622 ^+, ^-, ^n and ^n-m prefix operators in configuration
 - More tests for checking withdrawn hijacks
@@ -19,6 +18,8 @@
 ### Fixed
 - Updated/optimized db query for removing withdrawn peers (newer announcement)
 - Support for different user/pass on rabbitmq
+- Solved bug with randomized config hashing
+- Unneeded migration trigger with old containers on new DBs
 
 ### Deprecated
 - Backup files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Updated/optimized db query for removing withdrawn peers (newer announcement)
 - Support for different user/pass on rabbitmq
 - Solved bug with randomized config hashing
-- Unneeded migration trigger with old containers on new DBs
+- Fixed expected behavior when trying to run old containers on new DBs
 
 ### Deprecated
 - Backup files

--- a/backend/entrypoint
+++ b/backend/entrypoint
@@ -17,10 +17,14 @@ start_backend() {
     supervisord -n
 }
 
-if [ "$version" == "$DATABASE_VERSION" ]; then
+if [ $version -eq $DATABASE_VERSION ]; then
+    echo "[+] Running on intended database version ($DATABASE_VERSION).. No migration required"
+    start_backend
+elif [ $version -gt $DATABASE_VERSION ]; then
+    echo "[!] Running on a newer ($version) than intended ($DATABASE_VERSION) database version.. No migration required but keep an eye out for problems"
     start_backend
 else
-    echo "[!] Old Database version found.. Trying to migrate database automatically"
+    echo "[!] Older ($version) than intended ($DATABASE_VERSION) Database version found.. Trying to migrate database automatically"
     python -u migrate/migrate.py
     if [ "$?" -eq 0 ]; then
         echo "[+] Migration sucessful.."

--- a/backend/entrypoint
+++ b/backend/entrypoint
@@ -21,8 +21,11 @@ if [ $version -eq $DATABASE_VERSION ]; then
     echo "[+] Running on intended database version ($DATABASE_VERSION).. No migration required"
     start_backend
 elif [ $version -gt $DATABASE_VERSION ]; then
-    echo "[!] Running on a newer ($version) than intended ($DATABASE_VERSION) database version.. No migration required but keep an eye out for problems"
-    start_backend
+    echo "[!] Trying to run on a newer ($version) than intended ($DATABASE_VERSION) database version. Please do the following steps:"
+    echo "[!] git pull origin master"
+    echo "[!] docker-compose pull"
+    echo "[!] start ARTEMIS normally"
+    exit -1
 else
     echo "[!] Older ($version) than intended ($DATABASE_VERSION) Database version found.. Trying to migrate database automatically"
     python -u migrate/migrate.py

--- a/backend/entrypoint.test
+++ b/backend/entrypoint.test
@@ -16,10 +16,14 @@ start_backend() {
     supervisord -n
 }
 
-if [ "$version" == "$DATABASE_VERSION" ]; then
+if [ $version -eq $DATABASE_VERSION ]; then
+    echo "[+] Running on intended database version ($DATABASE_VERSION).. No migration required"
+    start_backend
+elif [ $version -gt $DATABASE_VERSION ]; then
+    echo "[!] Running on a newer ($version) than intended ($DATABASE_VERSION) database version.. No migration required but keep an eye out for problems"
     start_backend
 else
-    echo "[!] Old Database version found.. Trying to migrate database automatically"
+    echo "[!] Older ($version) than intended ($DATABASE_VERSION) Database version found.. Trying to migrate database automatically"
     python -u migrate/migrate.py
     if [ "$?" -eq 0 ]; then
         echo "[+] Migration sucessful.."

--- a/backend/entrypoint.test
+++ b/backend/entrypoint.test
@@ -20,8 +20,11 @@ if [ $version -eq $DATABASE_VERSION ]; then
     echo "[+] Running on intended database version ($DATABASE_VERSION).. No migration required"
     start_backend
 elif [ $version -gt $DATABASE_VERSION ]; then
-    echo "[!] Running on a newer ($version) than intended ($DATABASE_VERSION) database version.. No migration required but keep an eye out for problems"
-    start_backend
+    echo "[!] Trying to run on a newer ($version) than intended ($DATABASE_VERSION) database version. Please do the following steps:"
+    echo "[!] git pull origin master"
+    echo "[!] docker-compose pull"
+    echo "[!] start ARTEMIS normally"
+    exit -1
 else
     echo "[!] Older ($version) than intended ($DATABASE_VERSION) Database version found.. Trying to migrate database automatically"
     python -u migrate/migrate.py


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->
Allowing backend runs on newer DBs than intended

What component(s) does this PR affect?

- [x] Back-End (Database, Microservices, Containers, etc)
- [ ] Front-End (Flask, API, etc)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->
entrypoint, entrypoint.test

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Microservices, Containers, etc)
- [ ] Front-End (Flask, API, etc)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->

### Type
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [x] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [x] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation.
- [ ] I have updated the documentation accordingly.
