### PR TITLE
DB stat on number of monitor peers

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 # Docker specific configs
 # use only letters and numbers for the project name
 COMPOSE_PROJECT_NAME=artemis
-DB_VERSION=15
+DB_VERSION=16
 GUI_ENABLED=true
 SYSTEM_VERSION=latest
 HISTORIC=false

--- a/.env
+++ b/.env
@@ -39,7 +39,7 @@ WEBAPP_PORT=8000
 ADMIN_USER=admin
 ADMIN_PASS=admin123
 ADMIN_EMAIL=admin@admin
-JS_VERSION=1.0.0
+JS_VERSION=1.0.1
 
 # rabbitmq config
 RABBITMQ_HOST=rabbitmq

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Slack logging package and example
 - ARTEMIS logo
+- Monitor peers count in stats table (overview)
 
 ### Changed
 - Refactoring frontend (views, templates and static files are organized inside the folder render)

--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -468,7 +468,7 @@ class Database:
                     self.redis.sadd("peer-asns", msg_["peer_asn"])
                     if self.redis.scard("peer-asns") != len(self.monitor_peers):
                         for peer_asn in self.redis.sscan_iter("peer-asns"):
-                            self.monitor_peers.add(peer_asn)
+                            self.monitor_peers.add(int(peer_asn))
 
                         with get_wo_cursor(self.wo_conn) as db_cur:
                             db_cur.execute(
@@ -870,6 +870,11 @@ class Database:
                     self.monitor_peers.add(mon_peer)
                     redis_pipeline.sadd("peer-asns", mon_peer)
                 redis_pipeline.execute()
+
+                with get_wo_cursor(self.wo_conn) as db_cur:
+                    db_cur.execute(
+                        "UPDATE stats SET monitor_peers=%s;", (len(self.monitor_peers),)
+                    )
 
             except Exception:
                 log.exception("exception")

--- a/backend/core/detection.py
+++ b/backend/core/detection.py
@@ -374,10 +374,6 @@ class Detection:
 
             raw = monitor_event.copy()
 
-            # register the monitor/peer ASN from whom we learned this BGP update
-            if "peer_asn" in monitor_event:
-                self.redis.sadd("peer-asns", monitor_event["peer_asn"])
-
             # mark the initial redis hijack key since it may change upon
             # outdated checks
             if "hij_key" in monitor_event:

--- a/backend/hasura_init.json
+++ b/backend/hasura_init.json
@@ -170,6 +170,7 @@
               "columns": [
                 "monitored_prefixes",
                 "configured_prefixes",
+                "monitor_peers",
                 "total_hijacks",
                 "ignored_hijacks",
                 "resolved_hijacks",

--- a/backend/migrate/migrations/scripts/migration_16.sql
+++ b/backend/migrate/migrations/scripts/migration_16.sql
@@ -1,0 +1,21 @@
+DROP VIEW view_index_all_stats;
+
+ALTER TABLE stats ADD COLUMN monitor_peers BIGINT NOT NULL DEFAULT 0;
+
+UPDATE stats SET monitored_prefixes=0, configured_prefixes=0, monitor_peers=0;
+
+CREATE OR REPLACE VIEW view_index_all_stats
+AS
+SELECT stats.monitored_prefixes, stats.configured_prefixes, stats.monitor_peers,
+    (SELECT count(*) total_hijacks FROM hijacks WHERE key is not NULL),
+    (SELECT count(*) ignored_hijacks FROM hijacks WHERE ignored = true),
+    (SELECT count(*) resolved_hijacks FROM hijacks WHERE resolved = true),
+    (SELECT count(*) withdrawn_hijacks FROM hijacks WHERE withdrawn = true),
+    (SELECT count(*) mitigation_hijacks FROM hijacks WHERE under_mitigation = true),
+    (SELECT count(*) ongoing_hijacks FROM hijacks WHERE active = true),
+    (SELECT count(*) dormant_hijacks FROM hijacks WHERE dormant = true),
+    (SELECT count(*) acknowledged_hijacks FROM hijacks WHERE seen = true),
+    (SELECT count(*) outdated_hijacks FROM hijacks WHERE outdated = true),
+    (SELECT count(*) total_bgp_updates FROM bgp_updates WHERE key is not NULL),
+    (SELECT count(*) total_unhandled_updates FROM bgp_updates WHERE handled = false)
+FROM stats;

--- a/backend/migrate/migrations/target_steps.json
+++ b/backend/migrate/migrations/target_steps.json
@@ -89,6 +89,12 @@
             "db_version": "15",
             "description": "Drop view_stats and create view view_index_all_stats",
             "file": "migration_15.sql"
+        },
+        "16": {
+            "id": "16",
+            "db_version": "16",
+            "description": "Added monitor_peers column in stats table and re-initialized stats table",
+            "file": "migration_16.sql"
         }
     }
 }

--- a/backend/testing/db/data/tables.sql
+++ b/backend/testing/db/data/tables.sql
@@ -22,7 +22,7 @@ CREATE TRIGGER db_details_no_delete
 BEFORE DELETE ON db_details
 FOR EACH ROW EXECUTE PROCEDURE db_version_no_delete();
 
-INSERT INTO db_details (version, upgraded_on) VALUES (15, now());
+INSERT INTO db_details (version, upgraded_on) VALUES (16, now());
 
 CREATE TABLE IF NOT EXISTS bgp_updates (
     key VARCHAR ( 32 ) NOT NULL,
@@ -147,7 +147,8 @@ CREATE TABLE IF NOT EXISTS configs (
 
 CREATE TABLE IF NOT EXISTS stats (
     monitored_prefixes BIGINT NOT NULL DEFAULT 0,
-    configured_prefixes BIGINT NOT NULL DEFAULT 0
+    configured_prefixes BIGINT NOT NULL DEFAULT 0,
+    monitor_peers BIGINT NOT NULL DEFAULT 0
 );
 
 CREATE UNIQUE INDEX stats_one_row
@@ -164,7 +165,7 @@ CREATE TRIGGER stats_no_delete
 BEFORE DELETE ON stats
 FOR EACH ROW EXECUTE PROCEDURE stats_no_delete();
 
-INSERT INTO stats (monitored_prefixes, configured_prefixes) VALUES (0, 0);
+INSERT INTO stats (monitored_prefixes, configured_prefixes, monitor_peers) VALUES (0, 0, 0);
 
 CREATE OR REPLACE VIEW view_configs AS SELECT raw_config, comment, time_modified FROM configs;
 
@@ -174,7 +175,7 @@ CREATE OR REPLACE VIEW view_bgpupdates AS SELECT prefix, origin_as, peer_asn, as
 
 CREATE OR REPLACE VIEW view_index_all_stats
 AS
-SELECT stats.monitored_prefixes, stats.configured_prefixes,
+SELECT stats.monitored_prefixes, stats.configured_prefixes, stats.monitor_peers,
     (SELECT count(*) total_hijacks FROM hijacks WHERE key is not NULL),
     (SELECT count(*) ignored_hijacks FROM hijacks WHERE ignored = true),
     (SELECT count(*) resolved_hijacks FROM hijacks WHERE resolved = true),

--- a/frontend/webapp/render/static/js/custom/display_info.js
+++ b/frontend/webapp/render/static/js/custom/display_info.js
@@ -9,6 +9,7 @@ mapHelpText_stats['field_database'] = 'ARTEMIS module responsible for providing 
 
 mapHelpText_stats['field_stats_configured_prefixes'] = 'The total number of IPv4/IPv6 prefixes that are configured (as appearing in ARTEMIS rules).';
 mapHelpText_stats['field_stats_monitored_prefixes'] = 'The total number of IPv4/IPv6 prefixes that are actually monitored (super-prefixes include sub-prefixes).';
+mapHelpText_stats['field_stats_monitor_peers'] = 'The total number of monitors (ASNs) that peer with routing collector services, as observed by the system.';
 mapHelpText_stats['field_stats_total_bgp_updates'] = 'The total number of BGP updates seen on the monitors.';
 mapHelpText_stats['field_stats_total_unhandled_updates'] = 'The total number of BGP updates not processed by the detection (either because they are in the queue, or because the detection was not running when they were fed to the monitors).';
 mapHelpText_stats['field_stats_total_hijacks'] = 'The total number of hijack events stored in the system.';

--- a/frontend/webapp/render/templates/main/overview.htm
+++ b/frontend/webapp/render/templates/main/overview.htm
@@ -128,8 +128,36 @@
         {{super()}}
         <script>
             var table;
-            var hasura_stats = ["monitored_prefixes","configured_prefixes","monitor_peers","total_bgp_updates","total_unhandled_updates","total_hijacks","ignored_hijacks","resolved_hijacks","withdrawn_hijacks","mitigation_hijacks","ongoing_hijacks","dormant_hijacks","acknowledged_hijacks","outdated_hijacks"];
-            var hasura_fetch = ["time_detected","prefix","type","hijack_as","num_peers_seen","num_asns_inf","key","seen","active","dormant","under_mitigation","time_last","configured_prefix"];
+            var hasura_stats = [
+                "monitored_prefixes",
+                "configured_prefixes",
+                "monitor_peers",
+                "total_bgp_updates",
+                "total_unhandled_updates",
+                "total_hijacks",
+                "ignored_hijacks",
+                "resolved_hijacks",
+                "withdrawn_hijacks",
+                "mitigation_hijacks",
+                "ongoing_hijacks",
+                "dormant_hijacks",
+                "acknowledged_hijacks",
+                "outdated_hijacks"
+            ];
+            var hasura_fetch = [
+                "time_detected",
+                "prefix",
+                "type",
+                "hijack_as",
+                "num_peers_seen",
+                "num_asns_inf",
+                "key","seen",
+                "active",
+                "dormant",
+                "under_mitigation",
+                "time_last",
+                "configured_prefix"
+            ];
             var hasura = {
 
                 "subscription": {

--- a/frontend/webapp/render/templates/main/overview.htm
+++ b/frontend/webapp/render/templates/main/overview.htm
@@ -128,7 +128,7 @@
         {{super()}}
         <script>
             var table;
-            var hasura_stats = ["monitored_prefixes","configured_prefixes","total_bgp_updates","total_unhandled_updates","total_hijacks","ignored_hijacks","resolved_hijacks","withdrawn_hijacks","mitigation_hijacks","ongoing_hijacks","dormant_hijacks","acknowledged_hijacks","outdated_hijacks"];
+            var hasura_stats = ["monitored_prefixes","configured_prefixes","monitor_peers","total_bgp_updates","total_unhandled_updates","total_hijacks","ignored_hijacks","resolved_hijacks","withdrawn_hijacks","mitigation_hijacks","ongoing_hijacks","dormant_hijacks","acknowledged_hijacks","outdated_hijacks"];
             var hasura_fetch = ["time_detected","prefix","type","hijack_as","num_peers_seen","num_asns_inf","key","seen","active","dormant","under_mitigation","time_last","configured_prefix"];
             var hasura = {
 

--- a/other/db/data/tables.sql
+++ b/other/db/data/tables.sql
@@ -22,7 +22,7 @@ CREATE TRIGGER db_details_no_delete
 BEFORE DELETE ON db_details
 FOR EACH ROW EXECUTE PROCEDURE db_version_no_delete();
 
-INSERT INTO db_details (version, upgraded_on) VALUES (15, now());
+INSERT INTO db_details (version, upgraded_on) VALUES (16, now());
 
 CREATE TABLE IF NOT EXISTS bgp_updates (
     key VARCHAR ( 32 ) NOT NULL,
@@ -143,7 +143,8 @@ CREATE TABLE IF NOT EXISTS configs (
 
 CREATE TABLE IF NOT EXISTS stats (
     monitored_prefixes BIGINT NOT NULL DEFAULT 0,
-    configured_prefixes BIGINT NOT NULL DEFAULT 0
+    configured_prefixes BIGINT NOT NULL DEFAULT 0,
+    monitor_peers BIGINT NOT NULL DEFAULT 0
 );
 
 CREATE UNIQUE INDEX stats_one_row
@@ -160,7 +161,7 @@ CREATE TRIGGER stats_no_delete
 BEFORE DELETE ON stats
 FOR EACH ROW EXECUTE PROCEDURE stats_no_delete();
 
-INSERT INTO stats (monitored_prefixes, configured_prefixes) VALUES (0, 0);
+INSERT INTO stats (monitored_prefixes, configured_prefixes, monitor_peers) VALUES (0, 0, 0);
 
 CREATE OR REPLACE VIEW view_configs AS SELECT raw_config, comment, time_modified FROM configs;
 
@@ -170,7 +171,7 @@ CREATE OR REPLACE VIEW view_bgpupdates AS SELECT prefix, origin_as, peer_asn, as
 
 CREATE OR REPLACE VIEW view_index_all_stats
 AS
-SELECT stats.monitored_prefixes, stats.configured_prefixes,
+SELECT stats.monitored_prefixes, stats.configured_prefixes, stats.monitor_peers,
     (SELECT count(*) total_hijacks FROM hijacks WHERE key is not NULL),
     (SELECT count(*) ignored_hijacks FROM hijacks WHERE ignored = true),
     (SELECT count(*) resolved_hijacks FROM hijacks WHERE resolved = true),


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->

What component(s) does this PR affect?

- [X] Back-End (Database, Microservices, Containers, etc)
- [X] Front-End (Flask, API, etc)
- [X] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Microservices, Containers, etc)
- [ ] Front-End (Flask, API, etc)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #152 

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->
Pre-load the set of monitor peers from the stored DB BGP updates. Load this into redis, and update
redis whenever a new BGP update is seen. Update DB only if the redis set actually changes.

### Type
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [X] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [X] This change requires a change in the documentation.
- [ ] I have updated the documentation accordingly.
