### PR TITLE
JSON dump the monitor event for easier parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Refactoring frontend (views, templates and static files are organized inside the folder render)
 - Update hasura (1.0.0alpha42 -> 1.0.0alpha45)
 - Replaced $.ajax with fetch
+- Hijack logger output is now a JSON string
 
 ### Fixed
 - TBD (bug-fix)

--- a/backend/core/detection.py
+++ b/backend/core/detection.py
@@ -27,6 +27,7 @@ from utils import get_logger
 from utils import purge_redis_eph_pers_keys
 from utils import RABBITMQ_URI
 from utils import redis_key
+from utils import SetEncoder
 from utils import translate_rfc2622
 
 HIJACK_DIM_COMBINATIONS = [
@@ -806,7 +807,7 @@ class Detection:
                 serializer="yaml",
                 priority=0,
             )
-            hij_log.info("{}".format(result))
+            hij_log.info("{}".format(json.dumps(result, indent=4, cls=SetEncoder)))
 
         def mark_handled(self, monitor_event: Dict) -> NoReturn:
             """

--- a/backend/core/detection.py
+++ b/backend/core/detection.py
@@ -769,7 +769,7 @@ class Detection:
                     )
                     redis_pipeline.sadd("persistent-keys", hijack_value["key"])
                     result = hijack_value
-                    mail_log.info("{}".format(result))
+                    mail_log.info("{}".format(json.dumps(result, indent=4, cls=SetEncoder)))
                 redis_pipeline.set(redis_hijack_key, yaml.dump(result))
 
                 # store the origin, neighbor combination for this hijack BGP update

--- a/backend/core/utils/__init__.py
+++ b/backend/core/utils/__init__.py
@@ -244,6 +244,13 @@ def calculate_more_specifics(prefix, min_length, max_length):
     return prefix_list
 
 
+class SetEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, set):
+            return list(o)
+        return super(SetEncoder, self).default(o)
+
+
 def translate_rfc2622(input_prefix, just_match=False):
     """
     :param input_prefix: (str) input IPv4/IPv6 prefix that


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->
Sends the hijack event as a JSON parsable string to the hijack logger. 

What component(s) does this PR affect?

- [x] Back-End (Database, Microservices, Containers, etc)
- [ ] Front-End (Flask, API, etc)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Microservices, Containers, etc)
- [ ] Front-End (Flask, API, etc)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->

### Type
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [x] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation.
- [ ] I have updated the documentation accordingly.
