### PR TITLE
fixed bug in configuration (translation of hijacks to rules)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Hijack logger output is now a JSON string
 
 ### Fixed
-- TBD (bug-fix)
+- Bug with rule learning (hijack to rule dict) when empty neighbor
 
 ### Removed
 - TBD (removed a feature)

--- a/backend/core/configuration.py
+++ b/backend/core/configuration.py
@@ -301,7 +301,13 @@ class Configuration:
                 asns = set()
                 if self.redis.exists(hij_orig_neighb_set):
                     for element in self.redis.sscan_iter(hij_orig_neighb_set):
-                        (origin, neighbor) = list(map(int, element.decode().split("_")))
+                        (origin_str, neighbor_str) = element.decode().split("_")
+                        origin = None
+                        if origin_str != "None":
+                            origin = int(origin_str)
+                        neighbor = None
+                        if neighbor_str != "None":
+                            neighbor = int(neighbor_str)
                         if origin is not None:
                             asns.add(origin)
                             if origin not in orig_to_neighb:
@@ -316,7 +322,11 @@ class Configuration:
                 # learned rule prefix
                 rule_prefix = {
                     raw["prefix"]: "LEARNED_H_{}_P_{}".format(
-                        raw["key"], raw["prefix"].replace("/", "_").replace(".", "_").replace(":", "_")
+                        raw["key"],
+                        raw["prefix"]
+                        .replace("/", "_")
+                        .replace(".", "_")
+                        .replace(":", "_"),
                     )
                 }
 


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->

What component(s) does this PR affect?

- [X] Back-End (Database, Microservices, Containers, etc)
- [ ] Front-End (Flask, API, etc)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Microservices, Containers, etc)
- [ ] Front-End (Flask, API, etc)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #186 

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->

Take care of 'None' strings in redis values.

### Type
<!--- What types of changes does your code introduce? -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [X] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation.
- [ ] I have updated the documentation accordingly.
