### PR TITLE
Ensure ARTEMIS config file is not clobbered on pod restart

### DIFF
--- a/artemis-chart/templates/backend-deployment.yaml
+++ b/artemis-chart/templates/backend-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         - mountPath: /pvc
           name: backend-pvc
           subPath: configs
-        command: ['sh', '-c', 'cp -u /configmaps/config.yaml /configmaps/logging.yaml /configmaps/services.conf /pvc/']
+        command: ['sh', '-c', 'cp -n -u /configmaps/config.yaml /configmaps/logging.yaml /configmaps/services.conf /pvc/']
       - name: wait-for-rmq
         image: busybox
         command: ['sh', '-c', 'until nc -z {{ .Values.rabbitmqHost }} {{ .Values.rabbitmqPort}}; do echo waiting for services; sleep 10; done;']

--- a/artemis-chart/templates/monitor-deployment.yaml
+++ b/artemis-chart/templates/monitor-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         - mountPath: /pvc
           name: monitor-pvc
           subPath: configs
-        command: ['sh', '-c', 'cp -u /configmaps/logging.yaml /configmaps/mon-services.conf /pvc/']
+        command: ['sh', '-c', 'cp -n -u /configmaps/logging.yaml /configmaps/mon-services.conf /pvc/']
       - name: wait-for-service
         image: busybox
         command: ['sh', '-c', 'until nc -z {{ .Values.rabbitmqHost }} {{ .Values.rabbitmqPort}}; do echo waiting for services; sleep 10; done;']


### PR DESCRIPTION
### Description of PR

Previously when the backend pod restarted it would overwrite the config file in persistent storage with the one from the configmap (i.e., the default). The `-u` option to `cp` doesn't seem to be enough to prevent an overwrite (presumably the modification time of the file from the configmap cannot be trusted). Using both `-u` and the `-n` (no-clobber) option seems to work and prevent the persisted config file from being overwritten.

What component(s) does this PR affect?

- [ ] Back-End (Database, Microservices, Containers, etc)
- [ ] Front-End (Flask, API, etc)
- [ ] Docs
- [X] Build System

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Microservices, Containers, etc)
- [ ] Front-End (Flask, API, etc)
- [ ] Docs
- [ ] Build System

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->

### Type
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [X] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation.
- [ ] I have updated the documentation accordingly.
