### PR TITLE
Disabling coverage run on autoconf, using simple python instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Issue with multiple rules for same prefix(es) in detection
 - Update RIPE Stat API call for ASN to country mapping
 - Minor issue with deprecated version of routinator (upgraded to 0.6.4)
+- Disabled coverage run on tested observer
 
 ### Removed
 - TBD (removed a feature)

--- a/tester/autoconf/supervisor.d/services.conf
+++ b/tester/autoconf/supervisor.d/services.conf
@@ -34,7 +34,7 @@ stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 
 [program:observer]
-command=coverage run -a %(program_name)s.py
+command=/usr/local/bin/python %(program_name)s.py
 process_name=%(program_name)s
 numprocs=1
 directory=/root/core

--- a/tester/autoconf/tester.py
+++ b/tester/autoconf/tester.py
@@ -357,7 +357,9 @@ class AutoconfTester:
 
             connection.close()
 
+        print("[+] Sleeping for 5 seconds...")
         time.sleep(5)
+        print("[+] Instructing all processes to stop...")
         self.supervisor.supervisor.stopAllProcesses()
 
         self.waitProcess("listener", 0)  # 0 STOPPED
@@ -365,6 +367,7 @@ class AutoconfTester:
         self.waitProcess("configuration", 0)  # 0 STOPPED
         self.waitProcess("database", 0)  # 0 STOPPED
         self.waitProcess("observer", 0)  # 0 STOPPED
+        print("[+] All processes (listener, clock, conf, db and observer) are stopped.")
 
 
 if __name__ == "__main__":

--- a/tester/detection/supervisor.d/services.conf
+++ b/tester/detection/supervisor.d/services.conf
@@ -34,7 +34,7 @@ stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 
 [program:observer]
-command=coverage run -a %(program_name)s.py
+command=/usr/local/bin/python %(program_name)s.py
 process_name=%(program_name)s
 numprocs=1
 directory=/root/core

--- a/tester/rpki/supervisor.d/services.conf
+++ b/tester/rpki/supervisor.d/services.conf
@@ -34,7 +34,7 @@ stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 
 [program:observer]
-command=coverage run -a %(program_name)s.py
+command=/usr/local/bin/python %(program_name)s.py
 process_name=%(program_name)s
 numprocs=1
 directory=/root/core


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->

What component(s) does this PR affect?

- [X] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs (incl. wiki)
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs (incl. wiki)
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #349 

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->
Disabled coverage run on autoconf observer for the test. Same for the rest of the tests where we applied "coverage run". Substituted with simple python.
 
### Type
<!--- What types of changes does your code introduce? -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [X] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation.
- [ ] I have updated the documentation accordingly.
