### PR TITLE
Upgrade nginx to latest released version (v1.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added database migration check between latest release and current version
 
 ### Changed
-- TBD (Changed existing functionality)
+- Upgraded nginx to latest release (v1.17)
 
 ### Fixed
 - LIMIT query planner bug (http://datamangling.com/2014/01/17/limit-1-and-performance-in-a-postgres-query/)

--- a/artemis-chart/templates/nginx-deployment.yaml
+++ b/artemis-chart/templates/nginx-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         image: busybox
         command: ['sh', '-c', 'until nc -z {{ .Release.Name }}-{{ .Values.webappHost }}-svc {{ .Values.webappPort }} && nc -z {{ .Values.hasuraHost }} {{ .Values.hasuraPort }}; do echo waiting for services; sleep 10; done;']
       containers:
-      - image: nginx:1.15-alpine
+      - image: nginx:1.17-alpine
         name: nginx
         ports:
         - containerPort: 80

--- a/docker-compose.testcafe.yaml
+++ b/docker-compose.testcafe.yaml
@@ -130,7 +130,7 @@ services:
             SUPERVISOR_HOST: ${BACKEND_SUPERVISOR_HOST}
             SUPERVISOR_PORT: ${BACKEND_SUPERVISOR_PORT}
     nginx:
-        image: nginx:1.15-alpine
+        image: nginx:1.17-alpine
         container_name: nginx
         restart: always
         depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -147,7 +147,7 @@ services:
             # - ./local_configs/frontend/:/etc/artemis/
             - ./frontend/db/:/etc/webapp/db/
     nginx:
-        image: nginx:1.15-alpine
+        image: nginx:1.17-alpine
         container_name: nginx
         restart: always
         depends_on:

--- a/vagrant-vm/vagrant-docker-compose.yaml
+++ b/vagrant-vm/vagrant-docker-compose.yaml
@@ -143,7 +143,7 @@ services:
             - ./local_configs/frontend/:/etc/artemis/
             - ./frontend/db/:/etc/webapp/db/
     nginx:
-        image: nginx:1.15-alpine
+        image: nginx:1.17-alpine
         container_name: nginx
         restart: always
         depends_on:


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->

What component(s) does this PR affect?

- [x] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs (incl. wiki)
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs (incl. wiki)
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->

### Type
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [x] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [x] This change requires a change in the documentation.
- [x] I have updated the documentation accordingly.
