### PR TITLE
Upgrade bgpstream to latest (closes #372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Upgrade rabbitmq to latest release (v3.8.3)
 - Upgrade postgrest to latest release version (v7.0.0)
 - Upgraded hasura-engine to v1.1.0
+- Updated version of BGPStream on custom image (mavromat/bgpstream-redis:v1.3-bgpstream)
 
 ### Fixed
 - LIMIT query planner bug (http://datamangling.com/2014/01/17/limit-1-and-performance-in-a-postgres-query/)

--- a/monitor/Dockerfile
+++ b/monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM mavromat/bgpstream-redis:v1.2-bgpstream
+FROM mavromat/bgpstream-redis:v1.3-bgpstream
 
 LABEL maintainer="Dimitrios Mavrommatis <jim.mavrommatis@gmail.com>"
 


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->

What component(s) does this PR affect?

- [ ] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [x] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs (incl. wiki)
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs (incl. wiki)
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #372

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->

### Type
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [x] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [x This change requires a change in the documentation.
- [x] I have updated the documentation accordingly.
