### PR TITLE
Move base images to a monorepo

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM mavromat/artemis-backend-base:latest
+FROM mavromat/artemis-base-images:backend-1.0.0
 LABEL maintainer="Dimitrios Mavrommatis <jim.mavrommatis@gmail.com>"
 
 WORKDIR /root

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,7 @@ COPY ./webapp/render/static/js/custom/ /root/
 COPY ./minify-js.sh /root/
 RUN mkdir /root/prod/ && ./minify-js.sh
 
-FROM mavromat/alpine-python:3.6
+FROM mavromat/artemis-base-images:frontend-1.0.0
 
 WORKDIR /root
 

--- a/monitor/Dockerfile
+++ b/monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM mavromat/bgpstream-redis:v1.3-bgpstream
+FROM mavromat/artemis-base-images:monitor-1.0.0
 LABEL maintainer="Dimitrios Mavrommatis <jim.mavrommatis@gmail.com>"
 
 RUN apt-get update && \


### PR DESCRIPTION
Moved all the base images for artemis to a monorepo to have easier control over the releases and versions.