### PR TITLE
fix: override BGPSTREAM timestamp when not parsed correctly

### DIFF
--- a/monitor/core/taps/bgpstreamkafka.py
+++ b/monitor/core/taps/bgpstreamkafka.py
@@ -209,13 +209,21 @@ if __name__ == "__main__":
 
     ping_redis(redis)
 
+    start_time = int(time.time()) - START_TIME_OFFSET
+    # Bypass for https://github.com/FORTH-ICS-INSPIRE/artemis/issues/411#issuecomment-661325802
+    if "BGPSTREAM_TIMESTAMP_BYPASS" in os.environ:
+        log.warn(
+            "Using BGPSTREAM_TIMESTAMP_BYPASS, meaning BMP timestamps are thrown away from BGPStream"
+        )
+        start_time = 0
+
     try:
         run_bgpstream(
             args.prefixes_file,
             args.kafka_host,
             int(args.kafka_port),
             args.kafka_topic,
-            start=int(time.time()) - START_TIME_OFFSET,
+            start=start_time,
             end=0,
         )
     except Exception:


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->
Small bypass fix for #411
Introduced an environment variable called `BGPSTREAM_TIMESTAMP_BYPASS` which when defined for the monitor container sets the start time of bgpstreamkafka to 0. This is needed because PyBGPStream is not yet exposing the correct timestamp when parsing and we have this fix temporarily.

What component(s) does this PR affect?

- [x] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs (incl. wiki)
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs (incl. wiki)
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->

### Type
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [x] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation.
- [x] I have updated the documentation accordingly.
