### PR TITLE
GRAPHQL_URI env support (close/fix #416)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED] (latest) - YYYY-MM-DD
 ### Added
 - Redirection to login page when session is expired (#404)
+- Support for GRAPHQL_URI to be set via environment variables, or to take a lazy approach and set HASURA_HOST and HASURA_PORT env variables
 
 ### Changed
 - TBD (Changed existing functionality)

--- a/backend/core/utils/__init__.py
+++ b/backend/core/utils/__init__.py
@@ -79,7 +79,13 @@ RPKI_VALIDATOR_ENABLED = os.getenv("RPKI_VALIDATOR_ENABLED", "false")
 RPKI_VALIDATOR_HOST = os.getenv("RPKI_VALIDATOR_HOST", "routinator")
 RPKI_VALIDATOR_PORT = os.getenv("RPKI_VALIDATOR_PORT", 3323)
 TEST_ENV = os.getenv("TEST_ENV", "false")
-GRAPHQL_URI = "http://graphql:8080/v1alpha1/graphql"
+GRAPHQL_URI = os.enviorn.get('GRAPHQL_URI')
+if GRAPHQL_URI is None:
+    HASURA_HOST = os.getenv("HASURA_HOST", "graphql")
+    HASURA_PORT = os.getenv("HASURA_PORT", 8080)
+    GRAPHQL_URI = "http://{HASURA_HOST}:{HASURA_PORT}/v1alpha1/graphql".format(
+        HASURA_HOST=HASURA_HOST,
+        HASURA_PORT=HASURA_PORT)
 HASURA_GRAPHQL_ACCESS_KEY = os.getenv("HASURA_GRAPHQL_ACCESS_KEY", "@rt3m1s.")
 GUI_ENABLED = os.getenv("GUI_ENABLED", "true")
 

--- a/backend/core/utils/__init__.py
+++ b/backend/core/utils/__init__.py
@@ -84,8 +84,8 @@ if GRAPHQL_URI is None:
     HASURA_HOST = os.getenv("HASURA_HOST", "graphql")
     HASURA_PORT = os.getenv("HASURA_PORT", 8080)
     GRAPHQL_URI = "http://{HASURA_HOST}:{HASURA_PORT}/v1alpha1/graphql".format(
-        HASURA_HOST=HASURA_HOST,
-        HASURA_PORT=HASURA_PORT)
+        HASURA_HOST=HASURA_HOST, HASURA_PORT=HASURA_PORT
+    )
 HASURA_GRAPHQL_ACCESS_KEY = os.getenv("HASURA_GRAPHQL_ACCESS_KEY", "@rt3m1s.")
 GUI_ENABLED = os.getenv("GUI_ENABLED", "true")
 

--- a/backend/core/utils/__init__.py
+++ b/backend/core/utils/__init__.py
@@ -79,7 +79,7 @@ RPKI_VALIDATOR_ENABLED = os.getenv("RPKI_VALIDATOR_ENABLED", "false")
 RPKI_VALIDATOR_HOST = os.getenv("RPKI_VALIDATOR_HOST", "routinator")
 RPKI_VALIDATOR_PORT = os.getenv("RPKI_VALIDATOR_PORT", 3323)
 TEST_ENV = os.getenv("TEST_ENV", "false")
-GRAPHQL_URI = os.getenv('GRAPHQL_URI')
+GRAPHQL_URI = os.getenv("GRAPHQL_URI")
 if GRAPHQL_URI is None:
     HASURA_HOST = os.getenv("HASURA_HOST", "graphql")
     HASURA_PORT = os.getenv("HASURA_PORT", 8080)

--- a/backend/core/utils/__init__.py
+++ b/backend/core/utils/__init__.py
@@ -79,7 +79,7 @@ RPKI_VALIDATOR_ENABLED = os.getenv("RPKI_VALIDATOR_ENABLED", "false")
 RPKI_VALIDATOR_HOST = os.getenv("RPKI_VALIDATOR_HOST", "routinator")
 RPKI_VALIDATOR_PORT = os.getenv("RPKI_VALIDATOR_PORT", 3323)
 TEST_ENV = os.getenv("TEST_ENV", "false")
-GRAPHQL_URI = os.enviorn.get('GRAPHQL_URI')
+GRAPHQL_URI = os.getenv('GRAPHQL_URI')
 if GRAPHQL_URI is None:
     HASURA_HOST = os.getenv("HASURA_HOST", "graphql")
     HASURA_PORT = os.getenv("HASURA_PORT", 8080)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -125,6 +125,7 @@ services:
             API_PORT: ${API_PORT}
             HASURA_HOST: ${HASURA_HOST}
             HASURA_PORT: ${HASURA_PORT}
+            HASURA_GRAPHQL_ACCESS_KEY: ${HASURA_SECRET_KEY}
             SYSTEM_VERSION: ${SYSTEM_VERSION}
             BIND_IP: ${BIND_IP}
             WEBAPP_PORT: ${WEBAPP_PORT}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -84,6 +84,9 @@ services:
             MON_SUPERVISOR_PORT: ${MON_SUPERVISOR_PORT}
             REDIS_HOST: ${REDIS_HOST}
             REDIS_PORT: ${REDIS_PORT}
+            HASURA_HOST: ${HASURA_HOST}
+            HASURA_PORT: ${HASURA_PORT}
+            HASURA_GRAPHQL_ACCESS_KEY: ${HASURA_SECRET_KEY}
             HISTORIC: ${HISTORIC}
             GUI_ENABLED: ${GUI_ENABLED}
         volumes:

--- a/frontend/webapp/utils/__init__.py
+++ b/frontend/webapp/utils/__init__.py
@@ -23,7 +23,15 @@ MON_SUPERVISOR_URI = "http://{}:{}/RPC2".format(
 )
 
 API_URI = "http://{}:{}".format(API_HOST, API_PORT)
-GRAPHQL_URI = "http://graphql:8080/v1alpha1/graphql"
+
+GRAPHQL_URI = os.getenv("GRAPHQL_URI")
+if GRAPHQL_URI is None:
+    HASURA_HOST = os.getenv("HASURA_HOST", "graphql")
+    HASURA_PORT = os.getenv("HASURA_PORT", 8080)
+    GRAPHQL_URI = "http://{HASURA_HOST}:{HASURA_PORT}/v1alpha1/graphql".format(
+        HASURA_HOST=HASURA_HOST, HASURA_PORT=HASURA_PORT
+    )
+HASURA_GRAPHQL_ACCESS_KEY = os.getenv("HASURA_GRAPHQL_ACCESS_KEY", "@rt3m1s.")
 
 
 def flatten(items, seqtypes=(list, tuple)):

--- a/monitor/core/utils/__init__.py
+++ b/monitor/core/utils/__init__.py
@@ -34,8 +34,8 @@ if GRAPHQL_URI is None:
     HASURA_HOST = os.getenv("HASURA_HOST", "graphql")
     HASURA_PORT = os.getenv("HASURA_PORT", 8080)
     GRAPHQL_URI = "http://{HASURA_HOST}:{HASURA_PORT}/v1alpha1/graphql".format(
-        HASURA_HOST=HASURA_HOST,
-        HASURA_PORT=HASURA_PORT)
+        HASURA_HOST=HASURA_HOST, HASURA_PORT=HASURA_PORT
+    )
 HASURA_GRAPHQL_ACCESS_KEY = os.getenv("HASURA_GRAPHQL_ACCESS_KEY", "@rt3m1s.")
 GUI_ENABLED = os.getenv("GUI_ENABLED", "true")
 

--- a/monitor/core/utils/__init__.py
+++ b/monitor/core/utils/__init__.py
@@ -29,7 +29,13 @@ RABBITMQ_HOST = os.getenv("RABBITMQ_HOST", "rabbitmq")
 RABBITMQ_PORT = os.getenv("RABBITMQ_PORT", 5672)
 REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
 REDIS_PORT = os.getenv("REDIS_PORT", 6379)
-GRAPHQL_URI = "http://graphql:8080/v1alpha1/graphql"
+GRAPHQL_URI = os.enviorn.get('GRAPHQL_URI')
+if GRAPHQL_URI is None:
+    HASURA_HOST = os.getenv("HASURA_HOST", "graphql")
+    HASURA_PORT = os.getenv("HASURA_PORT", 8080)
+    GRAPHQL_URI = "http://{HASURA_HOST}:{HASURA_PORT}/v1alpha1/graphql".format(
+        HASURA_HOST=HASURA_HOST,
+        HASURA_PORT=HASURA_PORT)
 HASURA_GRAPHQL_ACCESS_KEY = os.getenv("HASURA_GRAPHQL_ACCESS_KEY", "@rt3m1s.")
 GUI_ENABLED = os.getenv("GUI_ENABLED", "true")
 

--- a/monitor/core/utils/__init__.py
+++ b/monitor/core/utils/__init__.py
@@ -29,7 +29,7 @@ RABBITMQ_HOST = os.getenv("RABBITMQ_HOST", "rabbitmq")
 RABBITMQ_PORT = os.getenv("RABBITMQ_PORT", 5672)
 REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
 REDIS_PORT = os.getenv("REDIS_PORT", 6379)
-GRAPHQL_URI = os.getenv('GRAPHQL_URI')
+GRAPHQL_URI = os.getenv("GRAPHQL_URI")
 if GRAPHQL_URI is None:
     HASURA_HOST = os.getenv("HASURA_HOST", "graphql")
     HASURA_PORT = os.getenv("HASURA_PORT", 8080)

--- a/monitor/core/utils/__init__.py
+++ b/monitor/core/utils/__init__.py
@@ -29,7 +29,7 @@ RABBITMQ_HOST = os.getenv("RABBITMQ_HOST", "rabbitmq")
 RABBITMQ_PORT = os.getenv("RABBITMQ_PORT", 5672)
 REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
 REDIS_PORT = os.getenv("REDIS_PORT", 6379)
-GRAPHQL_URI = os.enviorn.get('GRAPHQL_URI')
+GRAPHQL_URI = os.getenv('GRAPHQL_URI')
 if GRAPHQL_URI is None:
     HASURA_HOST = os.getenv("HASURA_HOST", "graphql")
     HASURA_PORT = os.getenv("HASURA_PORT", 8080)


### PR DESCRIPTION
### Description of PR
Add support for GRAPHQL_URI in backend and monitor codebases. If this is not set, default to constructing the URI using the original URI string using values from from HASURA_HOST and HASURA_PORT (which default to 'graphql' and '8080' respectively)

What component(s) does this PR affect?

- [X] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [X] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs (incl. wiki)
- [ ] Build System

### Related Issue
Resolves #416

### Solution
Adds the missing env variables to docker-compose.yaml. The monitor and backend processes now build the GRAPHQL_URI using the following logic:

If GRAPHQL_URI is specified in env, use this value
If it is not, build the URI using the values in HASURA_HOST and HASURA_PORT. For backwards compatibility, these default to 'graphql' and port '8080' respectively.

### Type
<!--- What types of changes does your code introduce? -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [X] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [X] This change requires a change in the documentation.
- [ ] I have updated the documentation accordingly.
