### PR TITLE
Implicit withdrawals are now generated also on correct subprefix routing

### DIFF
--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -559,8 +559,9 @@ class Database:
 
                     # register the monitor/peer ASN from whom we learned this BGP update
                     self.redis.sadd("peer-asns", msg_["peer_asn"])
-                    if self.redis.scard("peer-asns") != self.monitor_peers:
-                        self.monitor_peers = self.redis.scard("peer-asns")
+                    redis_peer_asns = self.redis.scard("peer-asns")
+                    if redis_peer_asns != self.monitor_peers:
+                        self.monitor_peers = redis_peer_asns
                         self.wo_db.execute(
                             "UPDATE stats SET monitor_peers=%s;", (self.monitor_peers,)
                         )

--- a/testing/autoignore/tester.py
+++ b/testing/autoignore/tester.py
@@ -143,7 +143,7 @@ class AutoignoreTester:
         print(
             '\033[92mTest "{}" - Receiving Batch #{} - Type {} - Remaining {}'.format(
                 self.curr_test,
-                self.curr_idx,
+                self.curr_idx + 1,
                 message.delivery_info["routing_key"],
                 self.expected_messages - 1,
             )

--- a/testing/detection/configs/config.yaml
+++ b/testing/detection/configs/config.yaml
@@ -1,6 +1,9 @@
 prefixes:
     8_prefix: &8_prefix
         - 10.0.0.0/8
+    9_prefixes: &9_prefixes
+      - 10.0.0.0/9
+      - 10.128.0.0/9
     16_prefix: &16_prefix
         - 10.0.0.0/16
     24_prefix_1: &24_prefix_1
@@ -73,6 +76,7 @@ asns:
 rules:
 - prefixes:
   - *8_prefix
+  - *9_prefixes
   origin_asns:
   - *8_origin
   neighbors:

--- a/testing/detection/configs/config.yaml
+++ b/testing/detection/configs/config.yaml
@@ -1,9 +1,11 @@
 prefixes:
-    8_prefix: &8_prefix
+    8_prefix_1: &8_prefix_1
         - 10.0.0.0/8
-    9_prefixes: &9_prefixes
-      - 10.0.0.0/9
-      - 10.128.0.0/9
+    8_prefix_2: &8_prefix_2
+        - 11.0.0.0/8
+    9_prefixes_2: &9_prefixes_2
+        - 11.0.0.0/9
+        - 11.128.0.0/9
     16_prefix: &16_prefix
         - 10.0.0.0/16
     24_prefix_1: &24_prefix_1
@@ -75,8 +77,9 @@ asns:
         - 1004
 rules:
 - prefixes:
-  - *8_prefix
-  - *9_prefixes
+  - *8_prefix_1
+  - *8_prefix_2
+  - *9_prefixes_2
   origin_asns:
   - *8_origin
   neighbors:

--- a/testing/detection/tester.py
+++ b/testing/detection/tester.py
@@ -137,7 +137,7 @@ class Tester:
         print(
             '\033[92mTest "{}" - Receiving Batch #{} - Type {} - Remaining {}'.format(
                 self.curr_test,
-                self.curr_idx,
+                self.curr_idx + 1,
                 message.delivery_info["routing_key"],
                 self.expected_messages - 1,
             )

--- a/testing/detection/testfiles/implicit_withdrawal_subprefix.json
+++ b/testing/detection/testfiles/implicit_withdrawal_subprefix.json
@@ -1,0 +1,154 @@
+[
+    {
+        "send": {
+            "key": "1",
+            "timestamp": 1,
+            "orig_path": [],
+            "communities": [],
+            "service": "a",
+            "type": "A",
+            "path": [8, 3, 2, 100],
+            "prefix": "10.0.0.0/8",
+            "peer_asn": 8
+        },
+        "detection_update_response": {
+            "key": "1",
+            "handled": true,
+            "matched_prefix": "10.0.0.0/8",
+            "origin_as": 100
+        },
+        "detection_hijack_response": {
+            "prefix": "10.0.0.0/8",
+            "hijack_as": 100,
+            "type": "E|0|-|-",
+            "time_started": 1.0,
+            "configured_prefix": "10.0.0.0/8"
+        },
+        "database_hijack_response": {
+            "type": "E|0|-|-",
+            "active": true,
+            "prefix": "10.0.0.0/8",
+            "asns_inf": [8, 2, 3],
+            "hijack_as": 100,
+            "peers_seen": [8],
+            "num_asns_inf": 3,
+            "num_peers_seen": 1,
+            "configured_prefix": "10.0.0.0/8"
+        }
+    },
+    {
+        "send": {
+            "key": "2",
+            "timestamp": 2,
+            "orig_path": [],
+            "communities": [],
+            "service": "a",
+            "type": "A",
+            "path": [9, 3, 2, 100],
+            "prefix": "10.0.0.0/8",
+            "peer_asn": 9
+        },
+        "detection_update_response": {
+            "key": "2",
+            "handled": true,
+            "matched_prefix": "10.0.0.0/8",
+            "origin_as": 100
+        },
+        "detection_hijack_response": {
+            "prefix": "10.0.0.0/8",
+            "hijack_as": 100,
+            "type": "E|0|-|-",
+            "time_started": 1.0,
+            "time_last": 2.0,
+            "configured_prefix": "10.0.0.0/8"
+        },
+        "database_hijack_response": {
+            "type": "E|0|-|-",
+            "active": true,
+            "prefix": "10.0.0.0/8",
+            "asns_inf": [9, 8, 2, 3],
+            "hijack_as": 100,
+            "peers_seen": [8, 9],
+            "num_asns_inf": 4,
+            "num_peers_seen": 2,
+            "configured_prefix": "10.0.0.0/8"
+        }
+    },
+    {
+        "send": {
+            "key": "3",
+            "timestamp": 3,
+            "orig_path": [],
+            "communities": [],
+            "service": "a",
+            "type": "A",
+            "path": [8, 3, 2, 1],
+            "prefix": "10.0.0.0/9",
+            "peer_asn": 8
+        },
+        "detection_update_response": [
+            {
+                "key": "3",
+                "handled": true,
+                "matched_prefix": "10.0.0.0/8",
+                "origin_as": 1
+            },
+            {
+                "handled": true,
+                "matched_prefix": "10.0.0.0/8",
+                "origin_as": -1
+            }
+        ],
+        "database_hijack_response": {
+            "type": "E|0|-|-",
+            "prefix": "10.0.0.0/8",
+            "asns_inf": [9, 8, 2, 3],
+            "hijack_as": 100,
+            "peers_seen": [8, 9],
+            "num_asns_inf": 4,
+            "num_peers_seen": 2,
+            "configured_prefix": "10.0.0.0/8",
+            "peers_withdrawn": [8],
+            "active": true
+        }
+    },
+    {
+        "send": {
+            "key": "4",
+            "timestamp": 4,
+            "orig_path": [],
+            "communities": [],
+            "service": "a",
+            "type": "A",
+            "path": [9, 3, 2, 1],
+            "prefix": "10.0.0.0/9",
+            "peer_asn": 9
+        },
+        "detection_update_response": [
+            {
+                "key": "4",
+                "handled": true,
+                "matched_prefix": "10.0.0.0/8",
+                "origin_as": 1
+            },
+            {
+                "handled": true,
+                "matched_prefix": "10.0.0.0/8",
+                "origin_as": -1
+            }
+        ],
+        "database_hijack_response": {
+            "type": "E|0|-|-",
+            "prefix": "10.0.0.0/8",
+            "asns_inf": [9, 8, 2, 3],
+            "hijack_as": 100,
+            "peers_seen": [8, 9],
+            "num_asns_inf": 4,
+            "num_peers_seen": 2,
+            "configured_prefix": "10.0.0.0/8",
+            "peers_withdrawn": [8,9],
+            "active": false,
+            "withdrawn": true
+        }
+    }
+]

--- a/testing/detection/testfiles/implicit_withdrawal_subprefix.json
+++ b/testing/detection/testfiles/implicit_withdrawal_subprefix.json
@@ -8,32 +8,32 @@
             "service": "a",
             "type": "A",
             "path": [8, 3, 2, 100],
-            "prefix": "10.0.0.0/8",
+            "prefix": "11.0.0.0/8",
             "peer_asn": 8
         },
         "detection_update_response": {
             "key": "1",
             "handled": true,
-            "matched_prefix": "10.0.0.0/8",
+            "matched_prefix": "11.0.0.0/8",
             "origin_as": 100
         },
         "detection_hijack_response": {
-            "prefix": "10.0.0.0/8",
+            "prefix": "11.0.0.0/8",
             "hijack_as": 100,
             "type": "E|0|-|-",
             "time_started": 1.0,
-            "configured_prefix": "10.0.0.0/8"
+            "configured_prefix": "11.0.0.0/8"
         },
         "database_hijack_response": {
             "type": "E|0|-|-",
             "active": true,
-            "prefix": "10.0.0.0/8",
+            "prefix": "11.0.0.0/8",
             "asns_inf": [8, 2, 3],
             "hijack_as": 100,
             "peers_seen": [8],
             "num_asns_inf": 3,
             "num_peers_seen": 1,
-            "configured_prefix": "10.0.0.0/8"
+            "configured_prefix": "11.0.0.0/8"
         }
     },
     {
@@ -45,33 +45,33 @@
             "service": "a",
             "type": "A",
             "path": [9, 3, 2, 100],
-            "prefix": "10.0.0.0/8",
+            "prefix": "11.0.0.0/8",
             "peer_asn": 9
         },
         "detection_update_response": {
             "key": "2",
             "handled": true,
-            "matched_prefix": "10.0.0.0/8",
+            "matched_prefix": "11.0.0.0/8",
             "origin_as": 100
         },
         "detection_hijack_response": {
-            "prefix": "10.0.0.0/8",
+            "prefix": "11.0.0.0/8",
             "hijack_as": 100,
             "type": "E|0|-|-",
             "time_started": 1.0,
             "time_last": 2.0,
-            "configured_prefix": "10.0.0.0/8"
+            "configured_prefix": "11.0.0.0/8"
         },
         "database_hijack_response": {
             "type": "E|0|-|-",
             "active": true,
-            "prefix": "10.0.0.0/8",
+            "prefix": "11.0.0.0/8",
             "asns_inf": [9, 8, 2, 3],
             "hijack_as": 100,
             "peers_seen": [8, 9],
             "num_asns_inf": 4,
             "num_peers_seen": 2,
-            "configured_prefix": "10.0.0.0/8"
+            "configured_prefix": "11.0.0.0/8"
         }
     },
     {
@@ -83,31 +83,31 @@
             "service": "a",
             "type": "A",
             "path": [8, 3, 2, 1],
-            "prefix": "10.0.0.0/9",
+            "prefix": "11.0.0.0/9",
             "peer_asn": 8
         },
         "detection_update_response": [
             {
                 "key": "3",
                 "handled": true,
-                "matched_prefix": "10.0.0.0/8",
+                "matched_prefix": "11.0.0.0/9",
                 "origin_as": 1
             },
             {
                 "handled": true,
-                "matched_prefix": "10.0.0.0/8",
+                "matched_prefix": "11.0.0.0/8",
                 "origin_as": -1
             }
         ],
         "database_hijack_response": {
             "type": "E|0|-|-",
-            "prefix": "10.0.0.0/8",
+            "prefix": "11.0.0.0/8",
             "asns_inf": [9, 8, 2, 3],
             "hijack_as": 100,
             "peers_seen": [8, 9],
             "num_asns_inf": 4,
             "num_peers_seen": 2,
-            "configured_prefix": "10.0.0.0/8",
+            "configured_prefix": "11.0.0.0/8",
             "peers_withdrawn": [8],
             "active": true
         }
@@ -121,31 +121,31 @@
             "service": "a",
             "type": "A",
             "path": [9, 3, 2, 1],
-            "prefix": "10.0.0.0/9",
+            "prefix": "11.128.0.0/9",
             "peer_asn": 9
         },
         "detection_update_response": [
             {
                 "key": "4",
                 "handled": true,
-                "matched_prefix": "10.0.0.0/8",
+                "matched_prefix": "11.128.0.0/9",
                 "origin_as": 1
             },
             {
                 "handled": true,
-                "matched_prefix": "10.0.0.0/8",
+                "matched_prefix": "11.0.0.0/8",
                 "origin_as": -1
             }
         ],
         "database_hijack_response": {
             "type": "E|0|-|-",
-            "prefix": "10.0.0.0/8",
+            "prefix": "11.0.0.0/8",
             "asns_inf": [9, 8, 2, 3],
             "hijack_as": 100,
             "peers_seen": [8, 9],
             "num_asns_inf": 4,
             "num_peers_seen": 2,
-            "configured_prefix": "10.0.0.0/8",
+            "configured_prefix": "11.0.0.0/8",
             "peers_withdrawn": [8,9],
             "active": false,
             "withdrawn": true

--- a/testing/rpki/tester.py
+++ b/testing/rpki/tester.py
@@ -136,7 +136,7 @@ class Tester:
         print(
             '\033[92mTest "{}" - Receiving Batch #{} - Type {} - Remaining {}'.format(
                 self.curr_test,
-                self.curr_idx,
+                self.curr_idx + 1,
                 message.delivery_info["routing_key"],
                 self.expected_messages - 1,
             )


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->

What component(s) does this PR affect?

- [X] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs (incl. wiki)
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs (incl. wiki)
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #438 

Blocks #436 #437 

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->
The main logic of this PR is the following:
1. Assume we have an active hijack for prefix N/M (where N = network address and M = prefix length) .
2. Currently, we treat correct routing updates for N/M as implicit withdrawals for the monitor that saw both the hijack and the "healed" path.
3. With this adjustment, we also treat correct routing updates for either N_1/M+1 or N_2/M+1 (where N_1, N_2 the network addresses of the direct more specifics of the original prefix) as implicit withdrawals for the hijacked N/M. 

Note that in a future issue we need to carefully account for what prefix space is currently healed; this PR is an approximation for direct more specifics advertised during the deaggregation process (it is OK to assume that subprefix routing done for the entire prefix space will result in the hijack being mitigated, even if we do not wait to see all subprefix announcements).

### Type
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [X] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation.
- [ ] I have updated the documentation accordingly.
