### PR TITLE
New table (dataplane_msms) and view (view_dataplane_msms) creation for hijack dataplane measurements (pings and traceroutes) #448

### DIFF
--- a/.env
+++ b/.env
@@ -56,7 +56,7 @@ RABBITMQ_IO_THREAD_POOL_SIZE=128
 # hasura config
 HASURA_HOST=graphql
 HASURA_PORT=8080
-HASURA_GUI=true
+HASURA_GUI=false
 
 # secret keys
 HASURA_SECRET_KEY=@rt3m1s.

--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 # Docker specific configs
 # use only letters and numbers for the project name
 COMPOSE_PROJECT_NAME=artemis
-DB_VERSION=21
+DB_VERSION=22
 GUI_ENABLED=true
 SYSTEM_VERSION=latest
 HISTORIC=false
@@ -56,7 +56,7 @@ RABBITMQ_IO_THREAD_POOL_SIZE=128
 # hasura config
 HASURA_HOST=graphql
 HASURA_PORT=8080
-HASURA_GUI=false
+HASURA_GUI=true
 
 # secret keys
 HASURA_SECRET_KEY=@rt3m1s.

--- a/artemis-chart/templates/configmap.yaml
+++ b/artemis-chart/templates/configmap.yaml
@@ -19,7 +19,7 @@ data:
   risId: {{ .Values.risId | default "8522" | quote }}
   dbHost: {{ .Release.Name }}-{{ .Values.dbHost | default "postgres" }}-svc
   dbPort: {{ .Values.dbPort | default "5432" | quote }}
-  dbVersion: {{ .Values.dbVersion | default "21" | quote }}
+  dbVersion: {{ .Values.dbVersion | default "22" | quote }}
   dbName: {{ .Values.dbName | default "artemis_db" | quote }}
   dbUser: {{ .Values.dbUser | default "artemis_user" | quote }}
   dbSchema: {{ .Values.dbSchema | default "public" | quote }}

--- a/artemis-chart/values.yaml
+++ b/artemis-chart/values.yaml
@@ -20,7 +20,7 @@ risId: 8522
 # database
 dbHost: postgres
 dbPort: 5432
-dbVersion: 21
+dbVersion: 22
 dbName: artemis_db
 dbUser: artemis_user
 dbPass: Art3m1s

--- a/backend/hasura_init.json
+++ b/backend/hasura_init.json
@@ -216,6 +216,36 @@
         "update_permissions": [],
         "delete_permissions": [],
         "event_triggers": []
+      },
+      {
+        "table": "view_dataplane_msms",
+        "object_relationships": [],
+        "array_relationships": [],
+        "insert_permissions": [],
+        "select_permissions": [
+          {
+            "role": "user",
+            "comment": null,
+            "permission": {
+              "allow_aggregations": true,
+              "columns": [
+                "hijack_key",
+                "valid_origin_as",
+                "hijack_as",
+                "dst_addr",
+                "msm_type",
+                "msm_id",
+                "msm_link",
+                "responding",
+                "hijacked"
+              ],
+              "filter": {}
+            }
+          }
+        ],
+        "update_permissions": [],
+        "delete_permissions": [],
+        "event_triggers": []
       }
     ],
     "query_templates": [],

--- a/backend/migrate/migrations/scripts/migration_22.sql
+++ b/backend/migrate/migrations/scripts/migration_22.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS dataplane_msms (
+    key VARCHAR ( 32 ) NOT NULL,
+    hijack_key VARCHAR(32) NOT NULL,
+    valid_origin_AS BIGINT,
+    hijack_AS BIGINT,
+    dst_addr inet,
+    msm_type VARCHAR(10),
+    msm_id BIGINT NOT NULL,
+    msm_link text,
+    responding VARCHAR(3) DEFAULT 'NA',
+    hijacked VARCHAR(3) DEFAULT 'NA',
+    PRIMARY KEY (key),
+    UNIQUE (key, hijack_key, msm_id)
+);
+
+CREATE OR REPLACE VIEW view_dataplane_msms AS SELECT hijack_key, valid_origin_AS, hijack_AS, dst_addr, msm_type, msm_id, msm_link, responding, hijacked FROM dataplane_msms;

--- a/backend/migrate/migrations/target_steps.json
+++ b/backend/migrate/migrations/target_steps.json
@@ -125,6 +125,12 @@
             "db_version": "21",
             "description": "Add loading column in process_states table",
             "file": "migration_21.sql"
+        },
+        "22": {
+            "id": "22",
+            "db_version": "22",
+            "description": "Creation of new dataplane_msms table and view_dataplane_msms view",
+            "file": "migration_22.sql"
         }
     }
 }

--- a/other/db/data/tables.sql
+++ b/other/db/data/tables.sql
@@ -22,7 +22,7 @@ CREATE TRIGGER db_details_no_delete
 BEFORE DELETE ON db_details
 FOR EACH ROW EXECUTE PROCEDURE db_version_no_delete();
 
-INSERT INTO db_details (version, upgraded_on) VALUES (21, now());
+INSERT INTO db_details (version, upgraded_on) VALUES (22, now());
 
 CREATE TABLE IF NOT EXISTS bgp_updates (
     key VARCHAR ( 32 ) NOT NULL,
@@ -241,3 +241,20 @@ CREATE FUNCTION search_bgpupdates_by_as_path_and_hijack_key(key text, as_paths B
     WHERE
         key = ANY(view_bgpupdates.hijack_key) and as_paths <@ view_bgpupdates.as_path
 $$ LANGUAGE sql STABLE;
+
+CREATE TABLE IF NOT EXISTS dataplane_msms (
+    key VARCHAR ( 32 ) NOT NULL,
+    hijack_key VARCHAR(32) NOT NULL,
+    valid_origin_AS BIGINT,
+    hijack_AS BIGINT,
+    dst_addr inet,
+    msm_type VARCHAR(10),
+    msm_id BIGINT NOT NULL,
+    msm_link text,
+    responding VARCHAR(3) DEFAULT 'NA',
+    hijacked VARCHAR(3) DEFAULT 'NA',
+    PRIMARY KEY (key),
+    UNIQUE (key, hijack_key, msm_id)
+);
+
+CREATE OR REPLACE VIEW view_dataplane_msms AS SELECT hijack_key, valid_origin_AS, hijack_AS, dst_addr, msm_type, msm_id, msm_link, responding, hijacked FROM dataplane_msms;

--- a/testing/detection/db/data/tables.sql
+++ b/testing/detection/db/data/tables.sql
@@ -22,7 +22,7 @@ CREATE TRIGGER db_details_no_delete
 BEFORE DELETE ON db_details
 FOR EACH ROW EXECUTE PROCEDURE db_version_no_delete();
 
-INSERT INTO db_details (version, upgraded_on) VALUES (21, now());
+INSERT INTO db_details (version, upgraded_on) VALUES (22, now());
 
 CREATE TABLE IF NOT EXISTS bgp_updates (
     key VARCHAR ( 32 ) NOT NULL,

--- a/testing/testcafe/tests/simple-flow.js
+++ b/testing/testcafe/tests/simple-flow.js
@@ -11,7 +11,7 @@ test('Simple Flow', async t => {
         .click(Selector('#submit'))
         .expect(Selector('li').withText('Clock').textContent).contains("Clock On 1/1")
         .expect(Selector('li').withText('Configuration').textContent).contains("Configuration On 1/1")
-        .expect(Selector('li').withText('Database v.21').textContent).contains("Database v.21 On 1/1")
+        .expect(Selector('li').withText('Database v.22').textContent).contains("Database v.22 On 1/1")
         .expect(Selector('li').withText('Detection').textContent).contains("Detection On 0/1")
         .expect(Selector('#modules_states').find('li').withText('Mitigation').textContent).contains("Mitigation On 0/1")
         .expect(Selector('#modules_states').find('li').withText('Monitor').textContent).contains("Monitor On 0/1")


### PR DESCRIPTION
### Description of PR
#448  I have create the new table named "dataplane_msms" in which we will save the results of the dataplane measurements (ping, traceroutes from RIPE Atlas) for a specific hijack detected by ARTEMIS. Furthermore, I have create a new view named "view_dataplane_msms" which help us to query the measurement results from the "dataplane_msms" in a safe manner for each hijack and display these to the frontend (with the help of the Graphql API)        

What component(s) does this PR affect?

- [X] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs (incl. wiki)
- [ ] Build System

### Type
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

Resolves #448 

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [X] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation.
- [ ] I have updated the documentation accordingly.
