### PR TITLE
Prepend sequence pattern matching plus in-unit-test rules

### DIFF
--- a/backend/core/configuration.py
+++ b/backend/core/configuration.py
@@ -1082,7 +1082,7 @@ class Configuration:
                 rule["neighbors"] = flatten(rule.get("neighbors", []))
                 if rule["neighbors"] == ["*"]:
                     rule["neighbors"] = [-1]
-                rule["prepend_seq"] = flatten(rule.get("prepend_seq", []))
+                rule["prepend_seq"] = list(map(flatten, rule.get("prepend_seq", [])))
                 rule["mitigation"] = flatten(rule.get("mitigation", "manual"))
                 rule["policies"] = flatten(rule.get("policies", []))
                 rule["community_annotations"] = rule.get("community_annotations", [])

--- a/backend/core/configuration.py
+++ b/backend/core/configuration.py
@@ -82,6 +82,7 @@ class Configuration:
                 "policies",
                 "origin_asns",
                 "neighbors",
+                "prepend_seq",
                 "mitigation",
                 "community_annotations",
             }
@@ -1076,9 +1077,12 @@ class Configuration:
                 rule["origin_asns"] = flatten(rule.get("origin_asns", []))
                 if rule["origin_asns"] == ["*"]:
                     rule["origin_asns"] = [-1]
+                if "neighbors" in rule and "prepend_seq" in rule:
+                    raise ArtemisError("neighbors-prepend_seq-mutually-exclusive", "")
                 rule["neighbors"] = flatten(rule.get("neighbors", []))
                 if rule["neighbors"] == ["*"]:
                     rule["neighbors"] = [-1]
+                rule["prepend_seq"] = flatten(rule.get("prepend_seq", []))
                 rule["mitigation"] = flatten(rule.get("mitigation", "manual"))
                 rule["policies"] = flatten(rule.get("policies", []))
                 rule["community_annotations"] = rule.get("community_annotations", [])

--- a/backend/core/detection.py
+++ b/backend/core/detection.py
@@ -48,12 +48,14 @@ HIJACK_DIM_COMBINATIONS = [
     ["S", "0", "-", "L"],
     ["S", "1", "-", "-"],
     ["S", "1", "-", "L"],
+    ["S", "P", "-", "-"],
     ["S", "-", "-", "-"],
     ["S", "-", "-", "L"],
     ["E", "0", "-", "-"],
     ["E", "0", "-", "L"],
     ["E", "1", "-", "-"],
     ["E", "1", "-", "L"],
+    ["E", "P", "-", "-"],
     ["E", "-", "-", "L"],
     ["Q", "0", "-", "-"],
     ["Q", "0", "-", "L"],
@@ -395,6 +397,7 @@ class Detection:
                     conf_obj = {
                         "origin_asns": rule["origin_asns"],
                         "neighbors": rule["neighbors"],
+                        "prepend_seq": rule.get("prepend_seq", []),
                         "policies": set(rule["policies"]),
                         "community_annotations": rule["community_annotations"],
                     }
@@ -463,6 +466,8 @@ class Detection:
             is_hijack = False
 
             if monitor_event["type"] == "A":
+                # save the original path as-is to preserve patterns (if needed)
+                monitor_event["orig_path"] = monitor_event["path"][::]
                 monitor_event["path"] = Detection.Worker.__clean_as_path(
                     monitor_event["path"]
                 )
@@ -717,6 +722,7 @@ class Detection:
                 yield self.detect_path_type_0_hijack
                 if path_len > 1:
                     yield self.detect_path_type_1_hijack
+                    yield self.detect_path_type_P_hijack
                     if path_len > 2:
                         yield self.detect_path_type_N_hijack
             yield self.detect_path_type_U_hijack
@@ -818,6 +824,54 @@ class Detection:
             ):
                 return (-1, "-")
             return (first_neighbor_asn, "1")
+
+        @exception_handler(log)
+        def detect_path_type_P_hijack(
+            self,
+            monitor_event: Dict,
+            prefix_node: Dict,
+            prefix_node_conf: Dict,
+            *args,
+            **kwargs
+        ) -> Tuple[int, str]:
+            """
+            Type-P hijack detection.
+            """
+            if "orig_path" not in monitor_event:
+                return (-1, "-")
+            orig_path = monitor_event["orig_path"]
+            pattern_matched = False
+            pattern_hijacker = -1
+            best_match_length = 0
+            if len(prefix_node_conf["prepend_seq"]):
+                for conf_seq in prefix_node_conf["prepend_seq"]:
+                    if len(orig_path) >= len(conf_seq) + 1:
+                        monitor_event_seq = orig_path[
+                            len(orig_path) - len(conf_seq) - 1 : -1
+                        ]
+                        if monitor_event_seq == conf_seq:
+                            pattern_matched = True
+                            break
+                        else:
+                            pattern_diffs = list(
+                                map(
+                                    lambda x: monitor_event_seq[x] - conf_seq[x],
+                                    range(len(conf_seq)),
+                                )
+                            )
+                            this_best_match_length = 0
+                            for diff in pattern_diffs[::-1]:
+                                if diff == 0:
+                                    this_best_match_length += 1
+                                else:
+                                    break
+                            best_match_length = max(
+                                best_match_length, this_best_match_length
+                            )
+            if len(prefix_node_conf["prepend_seq"]) == 0 or pattern_matched:
+                return (-1, "-")
+            pattern_hijacker = orig_path[len(orig_path) - best_match_length - 2]
+            return (pattern_hijacker, "P")
 
         @exception_handler(log)
         def detect_path_type_N_hijack(

--- a/backend/core/detection.py
+++ b/backend/core/detection.py
@@ -867,12 +867,12 @@ class Detection:
                             # calculate the actual differences in the current pattern;
                             # this creates a list of elements with values 0 on matched
                             # elements and !0 otherwise
-                            pattern_diffs = list(
-                                map(
-                                    lambda x: monitor_event_seq[x] - conf_seq[x],
-                                    range(len(conf_seq)),
+                            pattern_diffs = [
+                                observed_as - conf_as
+                                for observed_as, conf_as in zip(
+                                    monitor_event_seq, conf_seq
                                 )
-                            )
+                            ]
                             this_best_match_length = 0
                             # after reversing the pattern difference sequence (i.e., start with
                             # origin), find the greatest length of consecutive 0s (i.e., non-differences/matches)

--- a/backend/core/tests/test_configuration.py
+++ b/backend/core/tests/test_configuration.py
@@ -1,0 +1,74 @@
+import unittest
+from unittest.mock import MagicMock
+from unittest.mock import mock_open
+from unittest.mock import patch
+
+import configuration
+
+TEST_CONF_DATA = """
+prefixes:
+    prefix_1: &prefix_1
+    - 10.0.0.0/8
+    - 10.1.0.0/16
+asns:
+    origins: &origins
+    - 1
+    neighbors: &neighbors
+    - 2
+    - 3
+rules:
+    - prefixes:
+      - *prefix_1
+      origin_asns:
+      - *origins
+      neighbors:
+      - *neighbors
+      mitigation: manual
+    - prefixes:
+      - *prefix_1
+      origin_asns:
+      - *origins
+      prepend_seq:
+      - [4, 3, 2]
+      - [8, 7, 6, 5]
+      mitigation: manual
+"""
+
+
+class ConfigurationTester(unittest.TestCase):
+    @patch("builtins.open", mock_open(read_data=TEST_CONF_DATA))
+    @patch("redis.Redis", MagicMock())
+    @patch("configuration.ping_redis", MagicMock())
+    def setUp(self) -> None:
+        self.worker = configuration.Configuration.Worker(MagicMock())
+
+    def test_prefixes(self):
+        self.assertEqual(
+            set(self.worker.data["prefixes"]["prefix_1"]),
+            set(["10.0.0.0/8", "10.1.0.0/16"]),
+        )
+
+    def test_asns(self):
+        self.assertEqual(set(self.worker.data["asns"]["origins"]), set([1]))
+        self.assertEqual(set(self.worker.data["asns"]["neighbors"]), set([2, 3]))
+
+    def test_simple_rule_neighbors(self):
+        self.assertEqual(
+            set(self.worker.data["rules"][0]["prefixes"]),
+            set(["10.0.0.0/8", "10.1.0.0/16"]),
+        )
+        self.assertEqual(set(self.worker.data["rules"][0]["origin_asns"]), set([1]))
+        self.assertEqual(set(self.worker.data["rules"][0]["neighbors"]), set([2, 3]))
+
+    def test_simple_rule_prepend_seq(self):
+        self.assertEqual(
+            set(self.worker.data["rules"][1]["prefixes"]),
+            set(["10.0.0.0/8", "10.1.0.0/16"]),
+        )
+        self.assertEqual(set(self.worker.data["rules"][1]["origin_asns"]), set([1]))
+        self.assertEqual(self.worker.data["rules"][1]["prepend_seq"][0], [4, 3, 2])
+        self.assertEqual(self.worker.data["rules"][1]["prepend_seq"][1], [8, 7, 6, 5])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/core/tests/test_detection.py
+++ b/backend/core/tests/test_detection.py
@@ -537,7 +537,7 @@ class BGPHandlerTester(unittest.TestCase):
                 "prefixes": ["10.0.0.0/24"],
                 "origin_asns": [1],
                 "neighbors": [],
-                "prepend_seq": [[4, 4, 4, 3, 2, 1, 1]],
+                "prepend_seq": [[4, 4, 4, 3, 2, 1], [4, 4, 4, 3, 2, 1, 1]],
                 "mitigation": ["manual"],
                 "policies": [],
                 "community_annotations": [],

--- a/backend/core/tests/test_detection.py
+++ b/backend/core/tests/test_detection.py
@@ -12,12 +12,14 @@ class BGPHandlerTester(unittest.TestCase):
     S|0|-|L: sub-prefix announced by illegal origin and no-export policy violation
     S|1|-|-: sub-prefix announced by seemingly legal origin, but with an illegal first hop
     S|1|-|L: sub-prefix announced by seemingly legal origin, but with an illegal first hop and no-export policy violation
+    S|P|-|-: sub-prefix announced by seemingly legal origin, but with an illegal pattern afterwards
     S|-|-|-: not S|0|- or S|1|-, potential type-N or type-U hijack
     S|-|-|L: not S|0|- or S|1|-, potential type-N or type-U hijack and no-export policy violation
     E|0|-|-: exact-prefix announced by illegal origin
     E|0|-|-|L: exact-prefix announced by illegal origin and no-export policy violation
     E|1|-|-: exact-prefix announced by seemingly legal origin, but with an illegal first hop
     E|1|-|L: exact-prefix announced by seemingly legal origin, but with an illegal first hop and no-export policy violation
+    E|P|-|-: exact-prefix announced by seemingly legal origin, but with an illegal pattern afterwards
     Q|0|-|-: squatting hijack (is always '0' on the path dimension since any origin is illegal)
     Q|0|-|L: squatting hijack and no-export policy violation
     E|-|-|-: not a hijack
@@ -30,6 +32,11 @@ class BGPHandlerTester(unittest.TestCase):
     @patch("detection.Detection.Worker.config_request_rpc", MagicMock())
     def setUp(self) -> None:
         self.worker = detection.Detection.Worker(MagicMock())
+        self.worker.rules = []
+        self.worker.init_detection()
+
+    @patch("detection.Detection.Worker.commit_hijack")
+    def test_handle_bgp_update_subprefix_type_0(self, mock_commit_hijack):
         self.worker.rules = [
             {
                 "prefixes": ["10.0.0.0/24"],
@@ -38,52 +45,10 @@ class BGPHandlerTester(unittest.TestCase):
                 "mitigation": ["manual"],
                 "policies": [],
                 "community_annotations": [],
-            },
-            {
-                "prefixes": ["9.0.5.0/24"],
-                "origin_asns": [245],
-                "neighbors": [-1],
-                "policies": ["no-export"],
-                "mitigation": ["manual"],
-                "community_annotations": [],
-            },
-            {
-                "prefixes": ["9.0.6.0/24"],
-                "origin_asns": [245],
-                "neighbors": [2],
-                "policies": ["no-export"],
-                "mitigation": ["manual"],
-                "community_annotations": [],
-            },
-            {
-                "prefixes": ["8.0.0.0/24"],
-                "origin_asns": [],
-                "neighbors": [],
-                "policies": [],
-                "mitigation": ["manual"],
-                "community_annotations": [],
-            },
-            {
-                "prefixes": ["7.0.0.0/24"],
-                "origin_asns": [],
-                "neighbors": [],
-                "policies": ["no-export"],
-                "mitigation": ["manual"],
-                "community_annotations": [],
-            },
-            {
-                "prefixes": ["6.0.0.0/24", "6.0.0.0/25"],
-                "origin_asns": [1],
-                "neighbors": [2],
-                "mitigation": ["manual"],
-                "policies": [],
-                "community_annotations": [],
-            },
+            }
         ]
         self.worker.init_detection()
 
-    @patch("detection.Detection.Worker.commit_hijack")
-    def test_handle_bgp_update_subprefix_type_0(self, mock_commit_hijack):
         message = {
             "key": "1",
             "timestamp": 1,
@@ -103,6 +68,18 @@ class BGPHandlerTester(unittest.TestCase):
 
     @patch("detection.Detection.Worker.commit_hijack")
     def test_handle_bgp_update_subprefix_type_0_no_export(self, mock_commit_hijack):
+        self.worker.rules = [
+            {
+                "prefixes": ["9.0.5.0/24"],
+                "origin_asns": [245],
+                "neighbors": [-1],
+                "policies": ["no-export"],
+                "mitigation": ["manual"],
+                "community_annotations": [],
+            }
+        ]
+        self.worker.init_detection()
+
         message = {
             "key": "1",
             "timestamp": 1,
@@ -122,6 +99,18 @@ class BGPHandlerTester(unittest.TestCase):
 
     @patch("detection.Detection.Worker.commit_hijack")
     def test_handle_bgp_update_subprefix_type_1(self, mock_commit_hijack):
+        self.worker.rules = [
+            {
+                "prefixes": ["10.0.0.0/24"],
+                "origin_asns": [1],
+                "neighbors": [2],
+                "mitigation": ["manual"],
+                "policies": [],
+                "community_annotations": [],
+            }
+        ]
+        self.worker.init_detection()
+
         message = {
             "key": "1",
             "timestamp": 1,
@@ -141,6 +130,18 @@ class BGPHandlerTester(unittest.TestCase):
 
     @patch("detection.Detection.Worker.commit_hijack")
     def test_handle_bgp_update_subprefix_type_1_no_export(self, mock_commit_hijack):
+        self.worker.rules = [
+            {
+                "prefixes": ["9.0.6.0/24"],
+                "origin_asns": [245],
+                "neighbors": [2],
+                "policies": ["no-export"],
+                "mitigation": ["manual"],
+                "community_annotations": [],
+            }
+        ]
+        self.worker.init_detection()
+
         message = {
             "key": "1",
             "timestamp": 1,
@@ -160,6 +161,18 @@ class BGPHandlerTester(unittest.TestCase):
 
     @patch("detection.Detection.Worker.commit_hijack")
     def test_handle_bgp_update_subprefix_type_N(self, mock_commit_hijack):
+        self.worker.rules = [
+            {
+                "prefixes": ["10.0.0.0/24"],
+                "origin_asns": [1],
+                "neighbors": [2],
+                "mitigation": ["manual"],
+                "policies": [],
+                "community_annotations": [],
+            }
+        ]
+        self.worker.init_detection()
+
         message = {
             "key": "1",
             "timestamp": 1,
@@ -179,6 +192,18 @@ class BGPHandlerTester(unittest.TestCase):
 
     @patch("detection.Detection.Worker.commit_hijack")
     def test_handle_bgp_update_subprefix_type_N_no_export(self, mock_commit_hijack):
+        self.worker.rules = [
+            {
+                "prefixes": ["9.0.6.0/24"],
+                "origin_asns": [245],
+                "neighbors": [2],
+                "policies": ["no-export"],
+                "mitigation": ["manual"],
+                "community_annotations": [],
+            }
+        ]
+        self.worker.init_detection()
+
         message = {
             "key": "1",
             "timestamp": 1,
@@ -198,6 +223,18 @@ class BGPHandlerTester(unittest.TestCase):
 
     @patch("detection.Detection.Worker.commit_hijack")
     def test_handle_bgp_update_exact_type_0(self, mock_commit_hijack):
+        self.worker.rules = [
+            {
+                "prefixes": ["10.0.0.0/24"],
+                "origin_asns": [1],
+                "neighbors": [2],
+                "mitigation": ["manual"],
+                "policies": [],
+                "community_annotations": [],
+            }
+        ]
+        self.worker.init_detection()
+
         message = {
             "key": "1",
             "timestamp": 1,
@@ -217,6 +254,18 @@ class BGPHandlerTester(unittest.TestCase):
 
     @patch("detection.Detection.Worker.commit_hijack")
     def test_handle_bgp_update_exact_type_0_no_export(self, mock_commit_hijack):
+        self.worker.rules = [
+            {
+                "prefixes": ["9.0.5.0/24"],
+                "origin_asns": [245],
+                "neighbors": [-1],
+                "policies": ["no-export"],
+                "mitigation": ["manual"],
+                "community_annotations": [],
+            }
+        ]
+        self.worker.init_detection()
+
         message = {
             "key": "1",
             "timestamp": 1,
@@ -236,6 +285,18 @@ class BGPHandlerTester(unittest.TestCase):
 
     @patch("detection.Detection.Worker.commit_hijack")
     def test_handle_bgp_update_exact_type_1(self, mock_commit_hijack):
+        self.worker.rules = [
+            {
+                "prefixes": ["10.0.0.0/24"],
+                "origin_asns": [1],
+                "neighbors": [2],
+                "mitigation": ["manual"],
+                "policies": [],
+                "community_annotations": [],
+            }
+        ]
+        self.worker.init_detection()
+
         message = {
             "key": "1",
             "timestamp": 1,
@@ -255,6 +316,18 @@ class BGPHandlerTester(unittest.TestCase):
 
     @patch("detection.Detection.Worker.commit_hijack")
     def test_handle_bgp_update_exact_type_1_no_export(self, mock_commit_hijack):
+        self.worker.rules = [
+            {
+                "prefixes": ["9.0.6.0/24"],
+                "origin_asns": [245],
+                "neighbors": [2],
+                "policies": ["no-export"],
+                "mitigation": ["manual"],
+                "community_annotations": [],
+            }
+        ]
+        self.worker.init_detection()
+
         message = {
             "key": "1",
             "timestamp": 1,
@@ -274,6 +347,18 @@ class BGPHandlerTester(unittest.TestCase):
 
     @patch("detection.Detection.Worker.commit_hijack")
     def test_handle_bgp_update_squatting(self, mock_commit_hijack):
+        self.worker.rules = [
+            {
+                "prefixes": ["8.0.0.0/24"],
+                "origin_asns": [],
+                "neighbors": [],
+                "policies": [],
+                "mitigation": ["manual"],
+                "community_annotations": [],
+            }
+        ]
+        self.worker.init_detection()
+
         message = {
             "key": "1",
             "timestamp": 1,
@@ -293,6 +378,18 @@ class BGPHandlerTester(unittest.TestCase):
 
     @patch("detection.Detection.Worker.commit_hijack")
     def test_handle_bgp_update_squatting_no_export(self, mock_commit_hijack):
+        self.worker.rules = [
+            {
+                "prefixes": ["7.0.0.0/24"],
+                "origin_asns": [],
+                "neighbors": [],
+                "policies": ["no-export"],
+                "mitigation": ["manual"],
+                "community_annotations": [],
+            }
+        ]
+        self.worker.init_detection()
+
         message = {
             "key": "1",
             "timestamp": 1,
@@ -312,6 +409,18 @@ class BGPHandlerTester(unittest.TestCase):
 
     @patch("detection.Detection.Worker.commit_hijack")
     def test_handle_bgp_update_no_hijack(self, mock_commit_hijack):
+        self.worker.rules = [
+            {
+                "prefixes": ["10.0.0.0/24"],
+                "origin_asns": [1],
+                "neighbors": [2],
+                "mitigation": ["manual"],
+                "policies": [],
+                "community_annotations": [],
+            }
+        ]
+        self.worker.init_detection()
+
         message = {
             "key": "1",
             "timestamp": 1,
@@ -333,6 +442,18 @@ class BGPHandlerTester(unittest.TestCase):
             if value == "prefix_6.0.0.0/24_peer_4_hijacks":
                 return True
             return False
+
+        self.worker.rules = [
+            {
+                "prefixes": ["6.0.0.0/24"],
+                "origin_asns": [1],
+                "neighbors": [2],
+                "mitigation": ["manual"],
+                "policies": [],
+                "community_annotations": [],
+            }
+        ]
+        self.worker.init_detection()
 
         message = {
             "key": "2",
@@ -369,6 +490,18 @@ class BGPHandlerTester(unittest.TestCase):
                 return True
             return False
 
+        self.worker.rules = [
+            {
+                "prefixes": ["6.0.0.0/24", "6.0.0.0/25"],
+                "origin_asns": [1],
+                "neighbors": [2],
+                "mitigation": ["manual"],
+                "policies": [],
+                "community_annotations": [],
+            }
+        ]
+        self.worker.init_detection()
+
         message = {
             "key": "2",
             "timestamp": 2,
@@ -396,6 +529,70 @@ class BGPHandlerTester(unittest.TestCase):
         }
         for key, value in withdraw_msg.items():
             self.assertEqual(mock_producer.publish.call_args[0][0][key], value)
+
+    @patch("detection.Detection.Worker.commit_hijack")
+    def test_handle_bgp_update_exact_type_P(self, mock_commit_hijack):
+        self.worker.rules = [
+            {
+                "prefixes": ["10.0.0.0/24"],
+                "origin_asns": [1],
+                "neighbors": [],
+                "prepend_seq": [[4, 4, 4, 3, 2, 1, 1]],
+                "mitigation": ["manual"],
+                "policies": [],
+                "community_annotations": [],
+            }
+        ]
+        self.worker.init_detection()
+
+        message = {
+            "key": "1",
+            "timestamp": 1,
+            "orig_path": [],
+            "communities": [],
+            "service": "a",
+            "type": "A",
+            "path": [4, 4, 4, 3, 100, 1, 1, 1],
+            "prefix": "10.0.0.0/24",
+            "peer_asn": 4,
+        }
+        self.worker.handle_bgp_update(message)
+
+        self.assertTrue(mock_commit_hijack.called)
+        self.assertEqual(mock_commit_hijack.call_args[0][1], 100)
+        self.assertEqual(mock_commit_hijack.call_args[0][2], ["E", "P", "-", "-"])
+
+    @patch("detection.Detection.Worker.commit_hijack")
+    def test_handle_bgp_update_subprefix_type_P(self, mock_commit_hijack):
+        self.worker.rules = [
+            {
+                "prefixes": ["10.0.0.0/24"],
+                "origin_asns": [1],
+                "neighbors": [],
+                "prepend_seq": [[4, 4, 4, 3, 2]],
+                "mitigation": ["manual"],
+                "policies": [],
+                "community_annotations": [],
+            }
+        ]
+        self.worker.init_detection()
+
+        message = {
+            "key": "1",
+            "timestamp": 1,
+            "orig_path": [],
+            "communities": [],
+            "service": "a",
+            "type": "A",
+            "path": [4, 4, 4, 3, 100, 100, 3, 2, 1],
+            "prefix": "10.0.0.0/25",
+            "peer_asn": 4,
+        }
+        self.worker.handle_bgp_update(message)
+
+        self.assertTrue(mock_commit_hijack.called)
+        self.assertEqual(mock_commit_hijack.call_args[0][1], 100)
+        self.assertEqual(mock_commit_hijack.call_args[0][2], ["S", "P", "-", "-"])
 
 
 if __name__ == "__main__":

--- a/docs/basicconf.md
+++ b/docs/basicconf.md
@@ -183,6 +183,23 @@ The list of the ASNs of the neighbors of the aforementioned networks (owning the
 
 Note that if you want neighbor checks to be wildcarded, you can simply omit this section; however, you will not receive hijack alerts involving fake first hops since in this case, all first hops are considered legal.
 
+## Prepend sequence matching
+The pattern (seen as a prepend sequence of AS-hops) that legal origin ASes are allowed to use to advertise
+their prefixes. Essentially it is the part of the path beyond the origin AS that the user/operator knows
+about and uses for policy differentiation. Example:
+
+   ```
+   prepend_seq:
+     - [..., other_AS, origin],
+     - [..., other_AS, origin],
+     - ...
+   ```
+
+*Note: this rule configuration cannot be combined with `neighbors`, please use one or the other. Moreover,
+it cannot be combined with `no-export` policies, please use one or the other.*
+
+See [this issue](https://github.com/FORTH-ICS-INSPIRE/artemis/issues/443) for more details.
+
 ### Mitigation
 The action that you want to do when you press "Mitigate" in a hijack view page. By default it is set to "manual" (even if you omit this section), which resorts to essentially nothing (ARTEMIS as a passive monitoring and detection tool). However, you can also set here the location of a script that runs the code you need, with the following requirements:
 
@@ -295,6 +312,25 @@ Sample BGP update triggering a hijack alert:
 Sample legal BGP update:
 
     [..., ASN_B, ASN_A]: prefix_A
+
+#### Legal origin, fake prepend sequence pattern (+exact-prefix): E|P|-|-
+Rule:
+
+    - prefixes:
+        - prefix_A
+      origin_asns:
+        - ASN_A
+      prepend_seq:
+        - [ASN_C, ASN_B]
+      mitigation: manual
+
+Sample BGP update triggering a hijack alert:
+
+    [..., ASN_D, ASN_A]: prefix_A
+
+Sample legal BGP update:
+
+    [..., ASN_C, ASN_B, ASN_A]: prefix_A
 
 #### Sub-prefix: S|<code>&ast;</code>|-|-
 Rule:

--- a/docs/hijackinfo.md
+++ b/docs/hijackinfo.md
@@ -73,6 +73,7 @@ How a hijacker manipulates the path to a prefix. Can be:
 * **Type-0 (0)** hijack: the attacker announces a path with an illegal origin.
 * **Type-1 (1)** hijack: the attacker announces a path with a legal origin, but illegal first hop.
 * **Type-N (N)** hijack: the attacker fakes a link deep in the path (N=2: the 2nd hop is illegal, N=3: the 3rd hop is illegal, etc.)
+* **Type-P (P)** hijack: the attacker fakes a prepend sequence pattern in the AS-path (not related to type-N hijack; pattern can be an entire sequence of hops)
 * **Type-U (U)** hijack: the attacker does not change the path at all (can be combined with a sub-prefix hijack).
 
 Currently, ARTEMIS issues '-' for Type-N/U attacks (not supported).
@@ -105,11 +106,13 @@ ARTEMIS currently detects the following combinations:
 * **S|0|-|L**: sub-prefix announced by illegal origin and no-export policy violation.
 * **S|1|-|-**: sub-prefix announced by seemingly legal origin, but with an illegal first hop.
 * **S|1|-|L**: sub-prefix announced by seemingly legal origin, but with an illegal first hop and no-export policy violation.
+* **S|P|-|-**: sub-prefix announced by seemingly legal origin, but with an illegal hop pattern.
 * **S|-|-|-**: not S|0|- or S|1|-, potential type-N or type-U hijack.
 * **S|-|-|L**: not S|0|- or S|1|-, potential type-N or type-U hijack and no-export policy violation.
 * **E|0|-|-**: exact-prefix announced by illegal origin.
 * **E|0|-|-|L**: exact-prefix announced by illegal origin and no-export policy violation.
 * **E|1|-|-**: exact-prefix announced by seemingly legal origin, but with an illegal first hop.
+* **E|P|-|-**: exact-prefix announced by seemingly legal origin, but with an illegal hop pattern.
 * **E|1|-|L**: exact-prefix announced by seemingly legal origin, but with an illegal first hop and no-export policy violation.
 * **Q|0|-|-**: squatting hijack (is always '0' on the path dimension since any origin is illegal).
 * **Q|0|-|L**: squatting hijack (is always '0' on the path dimension since any origin is illegal) and no-export policy violation.

--- a/frontend/webapp/render/static/js/custom/display_info.js
+++ b/frontend/webapp/render/static/js/custom/display_info.js
@@ -39,6 +39,7 @@ mapHelpText_system['field_hijack_type'] = `The type of the hijack in 4 dimension
 <li>[Prefix] "Q" → Squatting hijack</li>
 <li>[Path] "0" → Type-0 hijack</li>
 <li>[Path] "1" → Type-1 hijack</li>
+<li>[Path] "P" → Type-P hijack</li>
 <li>[Path] "-" → Type-N or Type-U hijack (N/A)</li>
 <li>[Data plane] "-" → Blackholing, Imposture or MitM hijack (N/A)</li>
 <li>[Policy] "L" → Route Leak due to no-export policy violation</li>

--- a/frontend/webapp/render/templates/main/hijacks.htm
+++ b/frontend/webapp/render/templates/main/hijacks.htm
@@ -420,7 +420,7 @@
                                     $(this).children("div").show();
                                 }
                             }else if(search_table_map[index] == 'type'){
-                                var type_regex = /^\s*(([S|E|Q]\|[0|1|-]\|-\|[L-])|([S|E|Q]\|[0|1|-]\|-)|((S\|0)|(S\|1)|(E\|0)|(E\|1)|(Q\|0))|([S|E|Q|0|1|L]))\s*$/;
+                                var type_regex = /^\s*(([S|E|Q]\|[0|1|P|-]\|-\|[L-])|([S|E|Q]\|[0|1|P|-]\|-)|((S\|0)|(S\|1)|(S\|P)|(E\|0)|(E\|1)|(E\|P)|(Q\|0))|([S|E|Q|0|1|P|L]))\s*$/;
                                 if(type_regex.exec(value)){
                                     match_value = value.replace(/^\s+|\s+$/g, '');
                                     filter_parameters[search_table_map[index]] = match_value;

--- a/frontend/webapp/render/templates/main/overview.htm
+++ b/frontend/webapp/render/templates/main/overview.htm
@@ -498,7 +498,7 @@
                                     $(this).children("div").show();
                                 }
                             }else if(search_table_map[index] == 'type'){
-                                var type_regex = /^\s*(([S|E|Q]\|[0|1|-]\|-\|[L-])|([S|E|Q]\|[0|1|-]\|-)|((S\|0)|(S\|1)|(E\|0)|(E\|1)|(Q\|0))|([S|E|Q|0|1|L]))\s*$/;
+                                var type_regex = /^\s*(([S|E|Q]\|[0|1|P|-]\|-\|[L-])|([S|E|Q]\|[0|1|P|-]\|-)|((S\|0)|(S\|1)|(S\|P)|(E\|0)|(E\|1)|(E\|P)|(Q\|0))|([S|E|Q|0|1|P|L]))\s*$/;
                                 if(type_regex.exec(value)){
                                     match_value = value.replace(/^\s+|\s+$/g, '');
                                     filter_parameters[search_table_map[index]] = match_value;


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->

What component(s) does this PR affect?

- [X] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs (incl. wiki)
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs (incl. wiki)
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #443  #441

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->

### Type
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [X] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [x] This change requires a change in the documentation.
- [x] I have updated the documentation accordingly.

Need to update docs with new hijack type (in path dimension) called "P" (Pattern)