### PR TITLE
added correct redis command in compose to read conf file on startup

### DIFF
--- a/artemis-chart/templates/redis-deployment.yaml
+++ b/artemis-chart/templates/redis-deployment.yaml
@@ -22,6 +22,10 @@ spec:
       - name: redis
         image: {{ .image }}
         resources: {}
+        command:
+          - redis-server
+        args:
+          - /usr/local/etc/redis/redis.conf
         volumeMounts:
         - mountPath: /usr/local/etc/redis/redis.conf
           name: redis-configmap

--- a/backend-services/configs/redis.conf
+++ b/backend-services/configs/redis.conf
@@ -221,7 +221,7 @@ tcp-keepalive 300
 
 # By default Redis does not run as a daemon. Use 'yes' if you need it.
 # Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
-daemonize yes
+daemonize no
 
 # If you run Redis from upstart or systemd, Redis can interact with your
 # supervision tree. Options:

--- a/docker-compose.benchmark.yaml
+++ b/docker-compose.benchmark.yaml
@@ -387,6 +387,7 @@ services:
             - ${REDIS_PORT}
         volumes:
             - ./backend-services/redis/configs/redis.conf:/usr/local/etc/redis/redis.conf
+        command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
     rabbitmq:
         image: rabbitmq:3.8.3-management-alpine
         container_name: rabbitmq

--- a/docker-compose.testautoconf.yaml
+++ b/docker-compose.testautoconf.yaml
@@ -402,6 +402,7 @@ services:
             - ${REDIS_PORT}
         volumes:
             - ./backend-services/redis/configs/redis.conf:/usr/local/etc/redis/redis.conf
+        command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
     rabbitmq:
         image: rabbitmq:3.8.3-management-alpine
         container_name: rabbitmq

--- a/docker-compose.testautoignore.yaml
+++ b/docker-compose.testautoignore.yaml
@@ -402,6 +402,7 @@ services:
             - ${REDIS_PORT}
         volumes:
             - ./backend-services/redis/configs/redis.conf:/usr/local/etc/redis/redis.conf
+        command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
     rabbitmq:
         image: rabbitmq:3.8.3-management-alpine
         container_name: rabbitmq

--- a/docker-compose.testdetection.yaml
+++ b/docker-compose.testdetection.yaml
@@ -402,6 +402,7 @@ services:
             - ${REDIS_PORT}
         volumes:
             - ./backend-services/redis/configs/redis.conf:/usr/local/etc/redis/redis.conf
+        command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
     rabbitmq:
         image: rabbitmq:3.8.3-management-alpine
         container_name: rabbitmq

--- a/docker-compose.testrpki.yaml
+++ b/docker-compose.testrpki.yaml
@@ -402,6 +402,7 @@ services:
             - ${REDIS_PORT}
         volumes:
             - ./backend-services/redis/configs/redis.conf:/usr/local/etc/redis/redis.conf
+        command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
     rabbitmq:
         image: rabbitmq:3.8.3-management-alpine
         container_name: rabbitmq

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -372,6 +372,7 @@ services:
             - ${REDIS_PORT}
         volumes:
             - ./local_configs/backend/redis.conf:/usr/local/etc/redis/redis.conf
+        command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
     frontend:
         image: inspiregroup/artemis-tempfrontend:${SYSTEM_VERSION}
         build: ./frontend/

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced sets that are not supported by shared manager with lists
 - Removed unneeded read locks
 - Non-gracefull SIGKILL for taps in case graceful stop delays a lot
+- Redis configuration file input
 
 ### Removed
 - TBD (removed a feature)

--- a/docs/installsetup.md
+++ b/docs/installsetup.md
@@ -111,6 +111,7 @@ detailing all variables used in the .env file used for ARTEMIS system setup (non
    mkdir -p local_configs/monitor && \
    mkdir -p local_configs/frontend && \
    cp -rn backend-services/configs/* local_configs/backend && \
+   cp backend-services/configs/redis.conf local_configs/backend/redis.conf && \
    cp -rn monitor-services/configs/* local_configs/monitor && \
    cp -rn frontend/webapp/configs/* local_configs/frontend
    ```

--- a/other/docker-compose.testcafe.yaml
+++ b/other/docker-compose.testcafe.yaml
@@ -344,6 +344,7 @@ services:
             - ${REDIS_PORT}
         volumes:
             - ./backend-services/redis/configs/redis.conf:/usr/local/etc/redis/redis.conf
+        command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
     frontend:
         image: artemis_frontend
         build: ./frontend/

--- a/vagrant-vm/vagrant-docker-compose.yaml
+++ b/vagrant-vm/vagrant-docker-compose.yaml
@@ -345,6 +345,7 @@ services:
             - ${REDIS_PORT}
         volumes:
             - ./local_configs/backend-services/redis/redis.conf:/usr/local/etc/redis/redis.conf
+        command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
     frontend:
         image: inspiregroup/artemis-tempfrontend:${SYSTEM_VERSION}
         container_name: frontend


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->

What component(s) does this PR affect?

- [X] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #558

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->

### Type
<!--- What types of changes does your code introduce? -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [X] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation.
- [ ] I have updated the documentation accordingly.
