### PR TITLE
Reconfiguration flag and status in health + responsive config save

### DIFF
--- a/backend-services/autoignore/core/autoignore.py
+++ b/backend-services/autoignore/core/autoignore.py
@@ -38,6 +38,7 @@ shared_memory_locks = {
     "ongoing_hijacks": mp.Lock(),
     "config_timestamp": mp.Lock(),
     "time": mp.Lock(),
+    "service_reconfiguring": mp.Lock(),
 }
 
 # global vars
@@ -51,6 +52,9 @@ def configure_autoignore(msg, shared_memory_manager_dict):
         # check newer config
         config_timestamp = shared_memory_manager_dict["config_timestamp"]
         if config["timestamp"] > config_timestamp:
+            shared_memory_locks["service_reconfiguring"].acquire()
+            shared_memory_manager_dict["service_reconfiguring"] = True
+            shared_memory_locks["service_reconfiguring"].release()
 
             # extract autoignore rules
             autoignore_rules = config.get("autoignore", {})
@@ -70,10 +74,16 @@ def configure_autoignore(msg, shared_memory_manager_dict):
             shared_memory_manager_dict["time"] = 0
             shared_memory_locks["time"].release()
 
+        shared_memory_locks["service_reconfiguring"].acquire()
+        shared_memory_manager_dict["service_reconfiguring"] = False
+        shared_memory_locks["service_reconfiguring"].release()
         return {"success": True, "message": "configured"}
     except Exception:
         log.exception("exception")
-        return {"success": False, "message": "error during data worker configuration"}
+        shared_memory_locks["service_reconfiguring"].acquire()
+        shared_memory_manager_dict["service_reconfiguring"] = False
+        shared_memory_locks["service_reconfiguring"].release()
+        return {"success": False, "message": "error during service configuration"}
 
 
 class ConfigHandler(RequestHandler):
@@ -115,7 +125,7 @@ class ConfigHandler(RequestHandler):
             self.write(configure_autoignore(msg, self.shared_memory_manager_dict))
         except Exception:
             self.write(
-                {"success": False, "message": "error during data worker configuration"}
+                {"success": False, "message": "error during service configuration"}
             )
 
 
@@ -233,6 +243,7 @@ class Autoignore:
         shared_memory_manager = mp.Manager()
         self.shared_memory_manager_dict = shared_memory_manager.dict()
         self.shared_memory_manager_dict["data_worker_running"] = False
+        self.shared_memory_manager_dict["service_reconfiguring"] = False
         self.shared_memory_manager_dict["autoignore_rules"] = {}
         self.shared_memory_manager_dict["config_timestamp"] = -1
         self.shared_memory_manager_dict["time"] = 0

--- a/backend-services/autoignore/core/autoignore.py
+++ b/backend-services/autoignore/core/autoignore.py
@@ -140,13 +140,15 @@ class HealthHandler(RequestHandler):
     def get(self):
         """
         Extract the status of a service via a GET request.
-        :return: {"status" : <unconfigured|running|stopped>}
+        :return: {"status" : <unconfigured|running|stopped><,reconfiguring>}
         """
         status = "stopped"
         shared_memory_locks["data_worker"].acquire()
         if self.shared_memory_manager_dict["data_worker_running"]:
             status = "running"
         shared_memory_locks["data_worker"].release()
+        if self.shared_memory_manager_dict["service_reconfiguring"]:
+            status += ",reconfiguring"
         self.write({"status": status})
 
 

--- a/backend-services/configuration/core/configuration.py
+++ b/backend-services/configuration/core/configuration.py
@@ -1254,10 +1254,11 @@ def configure_configuration(msg, shared_memory_manager_dict):
                             if service not in services_to_notify:
                                 services_to_notify.append(service)
 
-                    # configure needed services with the new config
-                    post_configuration_to_other_services(
-                        shared_memory_manager_dict, services=services_to_notify
-                    )
+                    # configure needed services with the new config in background process
+                    mp.Process(
+                        target=post_configuration_to_other_services,
+                        args=(shared_memory_manager_dict, services_to_notify),
+                    ).start()
 
                     # if the change did not come from the file observer itself,
                     # we write the file

--- a/backend-services/configuration/core/configuration.py
+++ b/backend-services/configuration/core/configuration.py
@@ -1346,13 +1346,15 @@ class HealthHandler(RequestHandler):
     def get(self):
         """
         Extract the status of a service via a GET request.
-        :return: {"status" : <unconfigured|running|stopped>}
+        :return: {"status" : <unconfigured|running|stopped><,reconfiguring>}
         """
         status = "stopped"
         shared_memory_locks["data_worker"].acquire()
         if self.shared_memory_manager_dict["data_worker_running"]:
             status = "running"
         shared_memory_locks["data_worker"].release()
+        if self.shared_memory_manager_dict["service_reconfiguring"]:
+            status += ",reconfiguring"
         self.write({"status": status})
 
 

--- a/backend-services/database/core/database.py
+++ b/backend-services/database/core/database.py
@@ -322,13 +322,15 @@ class HealthHandler(RequestHandler):
     def get(self):
         """
         Extract the status of a service via a GET request.
-        :return: {"status" : <unconfigured|running|stopped>}
+        :return: {"status" : <unconfigured|running|stopped><,reconfiguring>}
         """
         status = "stopped"
         shared_memory_locks["data_worker"].acquire()
         if self.shared_memory_manager_dict["data_worker_running"]:
             status = "running"
         shared_memory_locks["data_worker"].release()
+        if self.shared_memory_manager_dict["service_reconfiguring"]:
+            status += ",reconfiguring"
         self.write({"status": status})
 
 

--- a/backend-services/database/core/database.py
+++ b/backend-services/database/core/database.py
@@ -55,6 +55,7 @@ shared_memory_locks = {
     "outdate_hijacks": mp.Lock(),
     "insert_hijacks_entries": mp.Lock(),
     "monitors": mp.Lock(),
+    "service_reconfiguring": mp.Lock(),
 }
 
 # global vars
@@ -162,6 +163,10 @@ def configure_database(msg, shared_memory_manager_dict):
         # check newer config
         config_timestamp = shared_memory_manager_dict["config_timestamp"]
         if config["timestamp"] > config_timestamp:
+            shared_memory_locks["service_reconfiguring"].acquire()
+            shared_memory_manager_dict["service_reconfiguring"] = True
+            shared_memory_locks["service_reconfiguring"].release()
+
             incoming_config_timestamp = config["timestamp"]
             if "timestamp" in config:
                 del config["timestamp"]
@@ -226,8 +231,15 @@ def configure_database(msg, shared_memory_manager_dict):
             shared_memory_manager_dict["config_timestamp"] = incoming_config_timestamp
             shared_memory_locks["config_timestamp"].release()
 
+        shared_memory_locks["service_reconfiguring"].acquire()
+        shared_memory_manager_dict["service_reconfiguring"] = False
+        shared_memory_locks["service_reconfiguring"].release()
         return {"success": True, "message": "configured"}
     except Exception:
+        log.exception("exception")
+        shared_memory_locks["service_reconfiguring"].acquire()
+        shared_memory_manager_dict["service_reconfiguring"] = False
+        shared_memory_locks["service_reconfiguring"].release()
         return {"success": False, "message": "error during service configuration"}
 
 
@@ -617,6 +629,7 @@ class Database:
         shared_memory_manager = mp.Manager()
         self.shared_memory_manager_dict = shared_memory_manager.dict()
         self.shared_memory_manager_dict["data_worker_running"] = False
+        self.shared_memory_manager_dict["service_reconfiguring"] = False
         self.shared_memory_manager_dict["monitored_prefixes"] = list()
         self.shared_memory_manager_dict["monitors"] = {}
         self.shared_memory_manager_dict["configured_prefix_count"] = 0

--- a/backend-services/detection/core/detection.py
+++ b/backend-services/detection/core/detection.py
@@ -119,13 +119,15 @@ class HealthHandler(RequestHandler):
     def get(self):
         """
         Extract the status of a service via a GET request.
-        :return: {"status" : <unconfigured|running|stopped>}
+        :return: {"status" : <unconfigured|running|stopped><,reconfiguring>}
         """
         status = "stopped"
         shared_memory_locks["data_worker"].acquire()
         if self.shared_memory_manager_dict["data_worker_running"]:
             status = "running"
         shared_memory_locks["data_worker"].release()
+        if self.shared_memory_manager_dict["service_reconfiguring"]:
+            status += ",reconfiguring"
         self.write({"status": status})
 
 
@@ -222,6 +224,7 @@ class Detection:
         shared_memory_manager = mp.Manager()
         self.shared_memory_manager_dict = shared_memory_manager.dict()
         self.shared_memory_manager_dict["data_worker_running"] = False
+        self.shared_memory_manager_dict["service_reconfiguring"] = False
 
         log.info("service initiated")
 

--- a/backend-services/fileobserver/core/observer.py
+++ b/backend-services/fileobserver/core/observer.py
@@ -67,13 +67,15 @@ class HealthHandler(RequestHandler):
     def get(self):
         """
         Extract the status of a service via a GET request.
-        :return: {"status" : <unconfigured|running|stopped>}
+        :return: {"status" : <unconfigured|running|stopped><,reconfiguring>}
         """
         status = "stopped"
         shared_memory_locks["data_worker"].acquire()
         if self.shared_memory_manager_dict["data_worker_running"]:
             status = "running"
         shared_memory_locks["data_worker"].release()
+        if self.shared_memory_manager_dict["service_reconfiguring"]:
+            status += ",reconfiguring"
         self.write({"status": status})
 
 
@@ -170,6 +172,7 @@ class FileObserver:
         shared_memory_manager = mp.Manager()
         self.shared_memory_manager_dict = shared_memory_manager.dict()
         self.shared_memory_manager_dict["data_worker_running"] = False
+        self.shared_memory_manager_dict["service_reconfiguring"] = False
         self.shared_memory_manager_dict["dirname"] = "/etc/artemis"
         self.shared_memory_manager_dict["filename"] = "config.yaml"
 

--- a/backend-services/mitigation/core/mitigation.py
+++ b/backend-services/mitigation/core/mitigation.py
@@ -67,13 +67,15 @@ class HealthHandler(RequestHandler):
     def get(self):
         """
         Extract the status of a service via a GET request.
-        :return: {"status" : <unconfigured|running|stopped>}
+        :return: {"status" : <unconfigured|running|stopped><,reconfiguring>}
         """
         status = "stopped"
         shared_memory_locks["data_worker"].acquire()
         if self.shared_memory_manager_dict["data_worker_running"]:
             status = "running"
         shared_memory_locks["data_worker"].release()
+        if self.shared_memory_manager_dict["service_reconfiguring"]:
+            status += ",reconfiguring"
         self.write({"status": status})
 
 
@@ -170,6 +172,7 @@ class Mitigation:
         shared_memory_manager = mp.Manager()
         self.shared_memory_manager_dict = shared_memory_manager.dict()
         self.shared_memory_manager_dict["data_worker_running"] = False
+        self.shared_memory_manager_dict["service_reconfiguring"] = False
 
         log.info("service initiated")
 

--- a/backend-services/notifier/core/notifier.py
+++ b/backend-services/notifier/core/notifier.py
@@ -130,13 +130,15 @@ class HealthHandler(RequestHandler):
     def get(self):
         """
         Extract the status of a service via a GET request.
-        :return: {"status" : <unconfigured|running|stopped>}
+        :return: {"status" : <unconfigured|running|stopped><,reconfiguring>}
         """
         status = "stopped"
         shared_memory_locks["data_worker"].acquire()
         if self.shared_memory_manager_dict["data_worker_running"]:
             status = "running"
         shared_memory_locks["data_worker"].release()
+        if self.shared_memory_manager_dict["service_reconfiguring"]:
+            status += ",reconfiguring"
         self.write({"status": status})
 
 

--- a/backend-services/prefixtree/core/prefixtree.py
+++ b/backend-services/prefixtree/core/prefixtree.py
@@ -47,6 +47,7 @@ shared_memory_locks = {
     "monitored_prefixes": mp.Lock(),
     "configured_prefix_count": mp.Lock(),
     "config_timestamp": mp.Lock(),
+    "service_reconfiguring": mp.Lock(),
 }
 
 # global vars
@@ -73,6 +74,9 @@ def configure_prefixtree(msg, shared_memory_manager_dict):
         # check newer config
         config_timestamp = shared_memory_manager_dict["config_timestamp"]
         if config["timestamp"] > config_timestamp:
+            shared_memory_locks["service_reconfiguring"].acquire()
+            shared_memory_manager_dict["service_reconfiguring"] = True
+            shared_memory_locks["service_reconfiguring"].release()
 
             # calculate prefix tree
             prefix_tree = {"v4": pytricia.PyTricia(32), "v6": pytricia.PyTricia(128)}
@@ -184,10 +188,16 @@ def configure_prefixtree(msg, shared_memory_manager_dict):
             shared_memory_manager_dict["config_timestamp"] = config["timestamp"]
             shared_memory_locks["config_timestamp"].release()
 
+        shared_memory_locks["service_reconfiguring"].acquire()
+        shared_memory_manager_dict["service_reconfiguring"] = False
+        shared_memory_locks["service_reconfiguring"].release()
         return {"success": True, "message": "configured"}
     except Exception:
         log.exception("exception")
-        return {"success": False, "message": "error during data worker configuration"}
+        shared_memory_locks["service_reconfiguring"].acquire()
+        shared_memory_manager_dict["service_reconfiguring"] = False
+        shared_memory_locks["service_reconfiguring"].release()
+        return {"success": False, "message": "error during service configuration"}
 
 
 class ConfigHandler(RequestHandler):
@@ -260,7 +270,7 @@ class ConfigHandler(RequestHandler):
             self.write(configure_prefixtree(msg, self.shared_memory_manager_dict))
         except Exception:
             self.write(
-                {"success": False, "message": "error during data worker configuration"}
+                {"success": False, "message": "error during service configuration"}
             )
 
 
@@ -420,6 +430,7 @@ class PrefixTree:
         shared_memory_manager = mp.Manager()
         self.shared_memory_manager_dict = shared_memory_manager.dict()
         self.shared_memory_manager_dict["data_worker_running"] = False
+        self.shared_memory_manager_dict["service_reconfiguring"] = False
         self.shared_memory_manager_dict["prefix_tree"] = {"v4": {}, "v6": {}}
         self.shared_memory_manager_dict["prefix_tree_recalculate"] = True
         self.shared_memory_manager_dict["monitored_prefixes"] = list()

--- a/backend-services/prefixtree/core/prefixtree.py
+++ b/backend-services/prefixtree/core/prefixtree.py
@@ -285,13 +285,15 @@ class HealthHandler(RequestHandler):
     def get(self):
         """
         Extract the status of a service via a GET request.
-        :return: {"status" : <unconfigured|running|stopped>}
+        :return: {"status" : <unconfigured|running|stopped><,reconfiguring>}
         """
         status = "stopped"
         shared_memory_locks["data_worker"].acquire()
         if self.shared_memory_manager_dict["data_worker_running"]:
             status = "running"
         shared_memory_locks["data_worker"].release()
+        if self.shared_memory_manager_dict["service_reconfiguring"]:
+            status += ",reconfiguring"
         self.write({"status": status})
 
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Action and necessary logic to un-mitigate a hijack
 - Ability to reload targeted services based on what conf section changed
 - GET config endpoints to backend and monitor services
+- Service reconfiguring flag and status
 
 ### Changed
 - Decoupled microservice architecture for backend and frontend

--- a/frontend/webapp/core/modules.py
+++ b/frontend/webapp/core/modules.py
@@ -109,7 +109,7 @@ class Modules_state:
     def is_up_or_running(self, module):
         try:
             r = requests.get("http://{}:{}/health".format(module, REST_PORT))
-            return r.json()["status"] == "running"
+            return r.json()["status"].startswith("running")
         except Exception:
             log.exception("exception")
             return False

--- a/monitor-services/bgpstreamhisttap/core/bgpstreamhist.py
+++ b/monitor-services/bgpstreamhisttap/core/bgpstreamhist.py
@@ -129,8 +129,9 @@ def configure_bgpstreamhist(msg, shared_memory_manager_dict):
 
             # check if "bgpstreamhist" is configured at all
             if "bgpstreamhist" not in monitors:
-                stop_msg = stop_data_worker(shared_memory_manager_dict)
-                log.info(stop_msg)
+                if shared_memory_manager_dict["data_worker_running"]:
+                    stop_msg = stop_data_worker(shared_memory_manager_dict)
+                    log.info(stop_msg)
                 shared_memory_locks["data_worker"].acquire()
                 shared_memory_manager_dict["data_worker_configured"] = False
                 shared_memory_locks["data_worker"].release()

--- a/monitor-services/bgpstreamhisttap/core/bgpstreamhist.py
+++ b/monitor-services/bgpstreamhisttap/core/bgpstreamhist.py
@@ -255,7 +255,7 @@ class HealthHandler(RequestHandler):
     def get(self):
         """
         Extract the status of a service via a GET request.
-        :return: {"status" : <unconfigured|running|stopped>}
+        :return: {"status" : <unconfigured|running|stopped><,reconfiguring>}
         """
         status = "stopped"
         shared_memory_locks["data_worker"].acquire()
@@ -264,6 +264,8 @@ class HealthHandler(RequestHandler):
         elif not self.shared_memory_manager_dict["data_worker_configured"]:
             status = "unconfigured"
         shared_memory_locks["data_worker"].release()
+        if self.shared_memory_manager_dict["service_reconfiguring"]:
+            status += ",reconfiguring"
         self.write({"status": status})
 
 

--- a/monitor-services/bgpstreamhisttap/core/bgpstreamhist.py
+++ b/monitor-services/bgpstreamhisttap/core/bgpstreamhist.py
@@ -35,6 +35,7 @@ shared_memory_locks = {
     "monitored_prefixes": mp.Lock(),
     "input_dir": mp.Lock(),
     "config_timestamp": mp.Lock(),
+    "service_reconfiguring": mp.Lock(),
 }
 
 # global vars
@@ -118,6 +119,10 @@ def configure_bgpstreamhist(msg, shared_memory_manager_dict):
         # check newer config
         config_timestamp = shared_memory_manager_dict["config_timestamp"]
         if config["timestamp"] > config_timestamp:
+            shared_memory_locks["service_reconfiguring"].acquire()
+            shared_memory_manager_dict["service_reconfiguring"] = True
+            shared_memory_locks["service_reconfiguring"].release()
+
             # get monitors
             r = requests.get("http://{}:{}/monitors".format(DATABASE_HOST, REST_PORT))
             monitors = r.json()["monitors"]
@@ -129,6 +134,9 @@ def configure_bgpstreamhist(msg, shared_memory_manager_dict):
                 shared_memory_locks["data_worker"].acquire()
                 shared_memory_manager_dict["data_worker_configured"] = False
                 shared_memory_locks["data_worker"].release()
+                shared_memory_locks["service_reconfiguring"].acquire()
+                shared_memory_manager_dict["service_reconfiguring"] = False
+                shared_memory_locks["service_reconfiguring"].release()
                 return {"success": True, "message": "data worker not in configuration"}
 
             # check if the worker should run (if configured)
@@ -167,10 +175,16 @@ def configure_bgpstreamhist(msg, shared_memory_manager_dict):
                 start_msg = start_data_worker(shared_memory_manager_dict)
                 log.info(start_msg)
 
+        shared_memory_locks["service_reconfiguring"].acquire()
+        shared_memory_manager_dict["service_reconfiguring"] = False
+        shared_memory_locks["service_reconfiguring"].release()
         return {"success": True, "message": "configured"}
     except Exception:
         log.exception("exception")
-        return {"success": False, "message": "error during data worker configuration"}
+        shared_memory_locks["service_reconfiguring"].acquire()
+        shared_memory_manager_dict["service_reconfiguring"] = False
+        shared_memory_locks["service_reconfiguring"].release()
+        return {"success": False, "message": "error during service configuration"}
 
 
 class ConfigHandler(RequestHandler):
@@ -226,7 +240,7 @@ class ConfigHandler(RequestHandler):
             self.write(configure_bgpstreamhist(msg, self.shared_memory_manager_dict))
         except Exception:
             self.write(
-                {"success": False, "message": "error during data worker configuration"}
+                {"success": False, "message": "error during service configuration"}
             )
 
 
@@ -297,6 +311,7 @@ class BGPStreamHistTap:
         shared_memory_manager = mp.Manager()
         self.shared_memory_manager_dict = shared_memory_manager.dict()
         self.shared_memory_manager_dict["data_worker_running"] = False
+        self.shared_memory_manager_dict["service_reconfiguring"] = False
         self.shared_memory_manager_dict["data_worker_should_run"] = False
         self.shared_memory_manager_dict["data_worker_configured"] = False
         self.shared_memory_manager_dict["monitored_prefixes"] = list()

--- a/monitor-services/bgpstreamkafkatap/core/bgpstreamkafka.py
+++ b/monitor-services/bgpstreamkafkatap/core/bgpstreamkafka.py
@@ -141,8 +141,9 @@ def configure_bgpstreamkafka(msg, shared_memory_manager_dict):
 
             # check if "bgpstreamkafka" is configured at all
             if "bgpstreamkafka" not in monitors:
-                stop_msg = stop_data_worker(shared_memory_manager_dict)
-                log.info(stop_msg)
+                if shared_memory_manager_dict["data_worker_running"]:
+                    stop_msg = stop_data_worker(shared_memory_manager_dict)
+                    log.info(stop_msg)
                 shared_memory_locks["data_worker"].acquire()
                 shared_memory_manager_dict["data_worker_configured"] = False
                 shared_memory_locks["data_worker"].release()

--- a/monitor-services/bgpstreamkafkatap/core/bgpstreamkafka.py
+++ b/monitor-services/bgpstreamkafkatap/core/bgpstreamkafka.py
@@ -44,6 +44,7 @@ shared_memory_locks = {
     "port": mp.Lock(),
     "topic": mp.Lock(),
     "config_timestamp": mp.Lock(),
+    "service_reconfiguring": mp.Lock(),
 }
 
 # global vars
@@ -130,6 +131,10 @@ def configure_bgpstreamkafka(msg, shared_memory_manager_dict):
         # check newer config
         config_timestamp = shared_memory_manager_dict["config_timestamp"]
         if config["timestamp"] > config_timestamp:
+            shared_memory_locks["service_reconfiguring"].acquire()
+            shared_memory_manager_dict["service_reconfiguring"] = True
+            shared_memory_locks["service_reconfiguring"].release()
+
             # get monitors
             r = requests.get("http://{}:{}/monitors".format(DATABASE_HOST, REST_PORT))
             monitors = r.json()["monitors"]
@@ -141,6 +146,9 @@ def configure_bgpstreamkafka(msg, shared_memory_manager_dict):
                 shared_memory_locks["data_worker"].acquire()
                 shared_memory_manager_dict["data_worker_configured"] = False
                 shared_memory_locks["data_worker"].release()
+                shared_memory_locks["service_reconfiguring"].acquire()
+                shared_memory_manager_dict["service_reconfiguring"] = False
+                shared_memory_locks["service_reconfiguring"].release()
                 return {"success": True, "message": "data worker not in configuration"}
 
             # check if the worker should run (if configured)
@@ -189,10 +197,16 @@ def configure_bgpstreamkafka(msg, shared_memory_manager_dict):
                 start_msg = start_data_worker(shared_memory_manager_dict)
                 log.info(start_msg)
 
+        shared_memory_locks["service_reconfiguring"].acquire()
+        shared_memory_manager_dict["service_reconfiguring"] = False
+        shared_memory_locks["service_reconfiguring"].release()
         return {"success": True, "message": "configured"}
     except Exception:
         log.exception("exception")
-        return {"success": False, "message": "error during data worker configuration"}
+        shared_memory_locks["service_reconfiguring"].acquire()
+        shared_memory_manager_dict["service_reconfiguring"] = False
+        shared_memory_locks["service_reconfiguring"].release()
+        return {"success": False, "message": "error during service configuration"}
 
 
 class ConfigHandler(RequestHandler):
@@ -254,7 +268,7 @@ class ConfigHandler(RequestHandler):
             self.write(configure_bgpstreamkafka(msg, self.shared_memory_manager_dict))
         except Exception:
             self.write(
-                {"success": False, "message": "error during data worker configuration"}
+                {"success": False, "message": "error during service configuration"}
             )
 
 
@@ -325,6 +339,7 @@ class BGPStreamKafkaTap:
         shared_memory_manager = mp.Manager()
         self.shared_memory_manager_dict = shared_memory_manager.dict()
         self.shared_memory_manager_dict["data_worker_running"] = False
+        self.shared_memory_manager_dict["service_reconfiguring"] = False
         self.shared_memory_manager_dict["data_worker_should_run"] = False
         self.shared_memory_manager_dict["data_worker_configured"] = False
         self.shared_memory_manager_dict["monitored_prefixes"] = list()

--- a/monitor-services/bgpstreamkafkatap/core/bgpstreamkafka.py
+++ b/monitor-services/bgpstreamkafkatap/core/bgpstreamkafka.py
@@ -283,7 +283,7 @@ class HealthHandler(RequestHandler):
     def get(self):
         """
         Extract the status of a service via a GET request.
-        :return: {"status" : <unconfigured|running|stopped>}
+        :return: {"status" : <unconfigured|running|stopped><,reconfiguring>}
         """
         status = "stopped"
         shared_memory_locks["data_worker"].acquire()
@@ -292,6 +292,8 @@ class HealthHandler(RequestHandler):
         elif not self.shared_memory_manager_dict["data_worker_configured"]:
             status = "unconfigured"
         shared_memory_locks["data_worker"].release()
+        if self.shared_memory_manager_dict["service_reconfiguring"]:
+            status += ",reconfiguring"
         self.write({"status": status})
 
 

--- a/monitor-services/bgpstreamlivetap/core/bgpstreamlive.py
+++ b/monitor-services/bgpstreamlivetap/core/bgpstreamlive.py
@@ -270,7 +270,7 @@ class HealthHandler(RequestHandler):
     def get(self):
         """
         Extract the status of a service via a GET request.
-        :return: {"status" : <unconfigured|running|stopped>}
+        :return: {"status" : <unconfigured|running|stopped><,reconfiguring>}
         """
         status = "stopped"
         shared_memory_locks["data_worker"].acquire()
@@ -279,6 +279,8 @@ class HealthHandler(RequestHandler):
         elif not self.shared_memory_manager_dict["data_worker_configured"]:
             status = "unconfigured"
         shared_memory_locks["data_worker"].release()
+        if self.shared_memory_manager_dict["service_reconfiguring"]:
+            status += ",reconfiguring"
         self.write({"status": status})
 
 

--- a/monitor-services/bgpstreamlivetap/core/bgpstreamlive.py
+++ b/monitor-services/bgpstreamlivetap/core/bgpstreamlive.py
@@ -141,8 +141,9 @@ def configure_bgpstreamlive(msg, shared_memory_manager_dict):
 
             # check if "bgpstreamlive" is configured at all
             if "bgpstreamlive" not in monitors:
-                stop_msg = stop_data_worker(shared_memory_manager_dict)
-                log.info(stop_msg)
+                if shared_memory_manager_dict["data_worker_running"]:
+                    stop_msg = stop_data_worker(shared_memory_manager_dict)
+                    log.info(stop_msg)
                 shared_memory_locks["data_worker"].acquire()
                 shared_memory_manager_dict["data_worker_configured"] = False
                 shared_memory_locks["data_worker"].release()

--- a/monitor-services/bgpstreamlivetap/core/bgpstreamlive.py
+++ b/monitor-services/bgpstreamlivetap/core/bgpstreamlive.py
@@ -42,6 +42,7 @@ shared_memory_locks = {
     "monitored_prefixes": mp.Lock(),
     "monitor_projects": mp.Lock(),
     "config_timestamp": mp.Lock(),
+    "service_reconfiguring": mp.Lock(),
 }
 
 # global vars
@@ -130,6 +131,10 @@ def configure_bgpstreamlive(msg, shared_memory_manager_dict):
         # check newer config
         config_timestamp = shared_memory_manager_dict["config_timestamp"]
         if config["timestamp"] > config_timestamp:
+            shared_memory_locks["service_reconfiguring"].acquire()
+            shared_memory_manager_dict["service_reconfiguring"] = True
+            shared_memory_locks["service_reconfiguring"].release()
+
             # get monitors
             r = requests.get("http://{}:{}/monitors".format(DATABASE_HOST, REST_PORT))
             monitors = r.json()["monitors"]
@@ -141,6 +146,9 @@ def configure_bgpstreamlive(msg, shared_memory_manager_dict):
                 shared_memory_locks["data_worker"].acquire()
                 shared_memory_manager_dict["data_worker_configured"] = False
                 shared_memory_locks["data_worker"].release()
+                shared_memory_locks["service_reconfiguring"].acquire()
+                shared_memory_manager_dict["service_reconfiguring"] = False
+                shared_memory_locks["service_reconfiguring"].release()
                 return {"success": True, "message": "data worker not in configuration"}
 
             # check if the worker should run (if configured)
@@ -180,10 +188,16 @@ def configure_bgpstreamlive(msg, shared_memory_manager_dict):
                 start_msg = start_data_worker(shared_memory_manager_dict)
                 log.info(start_msg)
 
+        shared_memory_locks["service_reconfiguring"].acquire()
+        shared_memory_manager_dict["service_reconfiguring"] = False
+        shared_memory_locks["service_reconfiguring"].release()
         return {"success": True, "message": "configured"}
     except Exception:
         log.exception("exception")
-        return {"success": False, "message": "error during data worker configuration"}
+        shared_memory_locks["service_reconfiguring"].acquire()
+        shared_memory_manager_dict["service_reconfiguring"] = False
+        shared_memory_locks["service_reconfiguring"].release()
+        return {"success": False, "message": "error during service configuration"}
 
 
 class ConfigHandler(RequestHandler):
@@ -241,7 +255,7 @@ class ConfigHandler(RequestHandler):
             self.write(configure_bgpstreamlive(msg, self.shared_memory_manager_dict))
         except Exception:
             self.write(
-                {"success": False, "message": "error during data worker configuration"}
+                {"success": False, "message": "error during service configuration"}
             )
 
 
@@ -312,6 +326,7 @@ class BGPStreamLiveTap:
         shared_memory_manager = mp.Manager()
         self.shared_memory_manager_dict = shared_memory_manager.dict()
         self.shared_memory_manager_dict["data_worker_running"] = False
+        self.shared_memory_manager_dict["service_reconfiguring"] = False
         self.shared_memory_manager_dict["data_worker_should_run"] = False
         self.shared_memory_manager_dict["data_worker_configured"] = False
         self.shared_memory_manager_dict["monitored_prefixes"] = list()

--- a/monitor-services/exabgptap/core/exabgp_client.py
+++ b/monitor-services/exabgptap/core/exabgp_client.py
@@ -115,8 +115,9 @@ def configure_exabgp(msg, shared_memory_manager_dict):
 
             # check if "exabgp" is configured at all
             if "exabgp" not in monitors:
-                stop_msg = stop_data_worker(shared_memory_manager_dict)
-                log.info(stop_msg)
+                if shared_memory_manager_dict["data_worker_running"]:
+                    stop_msg = stop_data_worker(shared_memory_manager_dict)
+                    log.info(stop_msg)
                 shared_memory_locks["data_worker"].acquire()
                 shared_memory_manager_dict["data_worker_configured"] = False
                 shared_memory_locks["data_worker"].release()

--- a/monitor-services/exabgptap/core/exabgp_client.py
+++ b/monitor-services/exabgptap/core/exabgp_client.py
@@ -250,7 +250,7 @@ class HealthHandler(RequestHandler):
     def get(self):
         """
         Extract the status of a service via a GET request.
-        :return: {"status" : <unconfigured|running|stopped>}
+        :return: {"status" : <unconfigured|running|stopped><,reconfiguring>}
         """
         status = "stopped"
         shared_memory_locks["data_worker"].acquire()
@@ -259,6 +259,8 @@ class HealthHandler(RequestHandler):
         elif not self.shared_memory_manager_dict["data_worker_configured"]:
             status = "unconfigured"
         shared_memory_locks["data_worker"].release()
+        if self.shared_memory_manager_dict["service_reconfiguring"]:
+            status += ",reconfiguring"
         self.write({"status": status})
 
 

--- a/monitor-services/riperistap/core/ripe_ris.py
+++ b/monitor-services/riperistap/core/ripe_ris.py
@@ -138,8 +138,9 @@ def configure_ripe_ris(msg, shared_memory_manager_dict):
 
             # check if "riperis" is configured at all
             if "riperis" not in monitors:
-                stop_msg = stop_data_worker(shared_memory_manager_dict)
-                log.info(stop_msg)
+                if shared_memory_manager_dict["data_worker_running"]:
+                    stop_msg = stop_data_worker(shared_memory_manager_dict)
+                    log.info(stop_msg)
                 shared_memory_locks["data_worker"].acquire()
                 shared_memory_manager_dict["data_worker_configured"] = False
                 shared_memory_locks["data_worker"].release()

--- a/monitor-services/riperistap/core/ripe_ris.py
+++ b/monitor-services/riperistap/core/ripe_ris.py
@@ -40,6 +40,7 @@ shared_memory_locks = {
     "monitored_prefixes": mp.Lock(),
     "hosts": mp.Lock(),
     "config_timestamp": mp.Lock(),
+    "service_reconfiguring": mp.Lock(),
 }
 
 # global vars
@@ -127,6 +128,10 @@ def configure_ripe_ris(msg, shared_memory_manager_dict):
         # check newer config
         config_timestamp = shared_memory_manager_dict["config_timestamp"]
         if config["timestamp"] > config_timestamp:
+            shared_memory_locks["service_reconfiguring"].acquire()
+            shared_memory_manager_dict["service_reconfiguring"] = True
+            shared_memory_locks["service_reconfiguring"].release()
+
             # get monitors
             r = requests.get("http://{}:{}/monitors".format(DATABASE_HOST, REST_PORT))
             monitors = r.json()["monitors"]
@@ -138,6 +143,9 @@ def configure_ripe_ris(msg, shared_memory_manager_dict):
                 shared_memory_locks["data_worker"].acquire()
                 shared_memory_manager_dict["data_worker_configured"] = False
                 shared_memory_locks["data_worker"].release()
+                shared_memory_locks["service_reconfiguring"].acquire()
+                shared_memory_manager_dict["service_reconfiguring"] = False
+                shared_memory_locks["service_reconfiguring"].release()
                 return {"success": True, "message": "data worker not in configuration"}
 
             # check if the worker should run (if configured)
@@ -179,10 +187,16 @@ def configure_ripe_ris(msg, shared_memory_manager_dict):
                 start_msg = start_data_worker(shared_memory_manager_dict)
                 log.info(start_msg)
 
+        shared_memory_locks["service_reconfiguring"].acquire()
+        shared_memory_manager_dict["service_reconfiguring"] = False
+        shared_memory_locks["service_reconfiguring"].release()
         return {"success": True, "message": "configured"}
     except Exception:
         log.exception("exception")
-        return {"success": False, "message": "error during data worker configuration"}
+        shared_memory_locks["service_reconfiguring"].acquire()
+        shared_memory_manager_dict["service_reconfiguring"] = False
+        shared_memory_locks["service_reconfiguring"].release()
+        return {"success": False, "message": "error during service configuration"}
 
 
 class ConfigHandler(RequestHandler):
@@ -238,7 +252,7 @@ class ConfigHandler(RequestHandler):
             self.write(configure_ripe_ris(msg, self.shared_memory_manager_dict))
         except Exception:
             self.write(
-                {"success": False, "message": "error during data worker configuration"}
+                {"success": False, "message": "error during service configuration"}
             )
 
 
@@ -309,6 +323,7 @@ class RipeRisTap:
         shared_memory_manager = mp.Manager()
         self.shared_memory_manager_dict = shared_memory_manager.dict()
         self.shared_memory_manager_dict["data_worker_running"] = False
+        self.shared_memory_manager_dict["service_reconfiguring"] = False
         self.shared_memory_manager_dict["data_worker_should_run"] = False
         self.shared_memory_manager_dict["data_worker_configured"] = False
         self.shared_memory_manager_dict["monitored_prefixes"] = list()

--- a/monitor-services/riperistap/core/ripe_ris.py
+++ b/monitor-services/riperistap/core/ripe_ris.py
@@ -267,7 +267,7 @@ class HealthHandler(RequestHandler):
     def get(self):
         """
         Extract the status of a service via a GET request.
-        :return: {"status" : <unconfigured|running|stopped>}
+        :return: {"status" : <unconfigured|running|stopped><,reconfiguring>}
         """
         status = "stopped"
         shared_memory_locks["data_worker"].acquire()
@@ -276,6 +276,8 @@ class HealthHandler(RequestHandler):
         elif not self.shared_memory_manager_dict["data_worker_configured"]:
             status = "unconfigured"
         shared_memory_locks["data_worker"].release()
+        if self.shared_memory_manager_dict["service_reconfiguring"]:
+            status += ",reconfiguring"
         self.write({"status": status})
 
 


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->

What component(s) does this PR affect?

- [X] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [X] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #561

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->

### Type
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [X] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation.
- [ ] I have updated the documentation accordingly.
