### PR TITLE
Hijack JSON export functionality

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GET config endpoints to backend and monitor services
 - Service reconfiguring flag and status
 - Redis no-data-received key expiry logic (default: 60 seconds)
+- Hijack detail JSON export
 
 ### Changed
 - Decoupled microservice architecture for backend and frontend

--- a/docs/hijackinfo.md
+++ b/docs/hijackinfo.md
@@ -182,6 +182,7 @@ Upon viewing a selected hijack event, the ADMIN user can execute the following a
   false positive until mitigated, resolved or marked explicitly. Note that acknowledging a hijack does not change any
   of its other states (e.g., if it is ongoing, it remains so).
 * **Delete**: This action will delete the hijack and all BGP messages related to it. Be cautious when deleting a hijack as this action cannot be undone.
+* **Export JSON**: This pseudo-action will query the Postgres DB via the PostgREST API and fetch the hijack details in JSON format (`<hijack_key>.json` file).
 
 **NOTE: Every hijack event should eventually be either resolved or ignored by an ADMIN user (or it can be auto-ignored by the system in case of limited impact/visibility).**
 

--- a/frontend/webapp/render/templates/main/hijack.htm
+++ b/frontend/webapp/render/templates/main/hijack.htm
@@ -185,6 +185,7 @@
                                 <div class="col-lg-4">
                                     <button id="hijack_apply_action" type="button" class="btn btn-primary btn-sm">Apply</button>
                                 </div>
+                                <a id="downloadHijackJSONElem" style="display:none"></a>
                             </div>
                         </div>
                     </div>
@@ -933,6 +934,7 @@
 
                 $('#hijack_acknowledged_badge').show();
                 $("#hijack_action_selection").append(new Option("Delete Hijack", "hijack_action_delete"));
+                $("#hijack_action_selection").append(new Option("Export JSON", "hijack_action_export_json"));
                 asn_map_to_name();
             }
 
@@ -990,6 +992,9 @@
                             "state": false,
                             "action": "seen"
                         }
+                    }else if(action == "hijack_action_export_json"){
+                        hijack_export_json_link(hijack_obj['key']);
+                        return;
                     }
                     if(obj){
                         postFetch_json(url, obj);
@@ -1196,6 +1201,24 @@
                     url += "&parameters=" + downloadTable_parameters;
                 }
                 $("#download_table_button").attr("href", url);
+            }
+
+            function hijack_export_json_link(hijack_key){
+                var url = "{{ url_for('proxy_api') }}" + "?download_table=true&action=view_hijacks";
+                if(hijack_key != null){
+                    url += "&parameters=(key.eq." + hijack_key + ")";
+                }
+                $.getJSON(url, function(data) {
+                    hijack_data = null;
+                    if(data.length > 0){
+                        hijack_data = data[0];
+                    }
+                    var hijackDataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(hijack_data));
+                    var dlHijackJSONElem = document.getElementById('downloadHijackJSONElem');
+                    dlHijackJSONElem.setAttribute("href",     hijackDataStr     );
+                    dlHijackJSONElem.setAttribute("download", hijack_key + ".json");
+                    dlHijackJSONElem.click();
+                });
             }
 
             function format_bgp_update_expand(d) {


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->

What component(s) does this PR affect?

- [ ] Back-End (Database, Detection/Configuration/etc. Microservices)
- [X] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #257 #446 

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->
Simple functionality addition in hijack details page.

### Type
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [X] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [X] This change requires a change in the documentation.
- [X] I have updated the documentation accordingly.
