### PR TITLE
[WIP] RFC2622 v6 tests and fix

### DIFF
--- a/backend-services/prefixtree/core/prefixtree.py
+++ b/backend-services/prefixtree/core/prefixtree.py
@@ -718,8 +718,8 @@ class PrefixTreeDataWorker(ConsumerProducerMixin):
                     routing_key="update-with-prefix-node",
                     serializer="ujson",
                 )
-            # else:
-            #     log.warning("unconfigured BGP update received '{}'".format(bgp_update))
+            else:
+                log.warning("unconfigured BGP update received '{}'".format(bgp_update))
         except Exception:
             log.exception("exception")
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - autoconfiguration subprefix bug in prefixtree plus new autoconf tests
 - vagrant docker-compose.yaml file fix (sync with master)
 - session timeout behavior
+- rfc2622 fix and tests
 
 ### Removed
 - TBD (removed a feature)

--- a/testing/detection/configs/config3.yaml
+++ b/testing/detection/configs/config3.yaml
@@ -23,6 +23,10 @@ prefixes:
         - 10.12.0.0/16^24
     test_n_m_op_16: &test_n_m_op_16
         - 10.13.0.0/16^20-24
+    test_n_op_32: &test_n_op_32
+        - 2001:db8::/32^48
+    test_n_m_op_32: &test_n_m_op_32
+        - 2001:db9::/32^32-48
     test_comms_24: &test_comms_24
         - 10.0.20.0/24
     test_as_set_24: &test_as_set_24
@@ -112,6 +116,8 @@ rules:
   - *test_inc_op_23
   - *test_n_op_16
   - *test_n_m_op_16
+  - *test_n_op_32
+  - *test_n_m_op_32
   origin_asns:
   - *op_test_origin
   neighbors:

--- a/testing/detection/testfiles/rfc2622.json
+++ b/testing/detection/testfiles/rfc2622.json
@@ -146,5 +146,79 @@
             "num_peers_seen": 1,
             "configured_prefix": "10.13.1.0/24"
         }
+    },
+    {
+        "send": {
+            "key": "30",
+            "timestamp": 30,
+            "orig_path": [],
+            "communities": [],
+            "service": "a",
+            "type": "A",
+            "path": [6, 3, 2, 202],
+            "prefix": "2001:db8:859::/48",
+            "peer_asn": 6
+        },
+        "detection_update_response": {
+            "key": "30",
+            "handled": true,
+            "matched_prefix": "2001:db8::/48",
+            "origin_as": 202
+        },
+        "detection_hijack_response": {
+            "prefix": "2001:db8:859::/48",
+            "hijack_as": 202,
+            "type": "E|0|-|-",
+            "time_started": 30.0,
+            "configured_prefix": "2001:db8::/48"
+        },
+        "database_hijack_response": {
+            "type": "E|0|-|-",
+            "active": true,
+            "prefix": "2001:db8:859::/48",
+            "asns_inf": [2, 3, 6],
+            "hijack_as": 202,
+            "peers_seen": [6],
+            "num_asns_inf": 3,
+            "num_peers_seen": 1,
+            "configured_prefix": "2001:db8::/48"
+        }
+    },
+    {
+        "send": {
+            "key": "31",
+            "timestamp": 31,
+            "orig_path": [],
+            "communities": [],
+            "service": "b",
+            "type": "A",
+            "path": [7, 3, 2, 203],
+            "prefix": "2001:db9:859::/48",
+            "peer_asn": 7
+        },
+        "detection_update_response": {
+            "key": "31",
+            "handled": true,
+            "matched_prefix": "2001:db9::/48",
+            "origin_as": 203
+        },
+        "detection_hijack_response": {
+            "prefix": "2001:db9:859::/48",
+            "hijack_as": 203,
+            "type": "E|0|-|-",
+            "time_started": 31.0,
+            "configured_prefix": "2001:db9::/48"
+        },
+        "database_hijack_response": {
+            "type": "E|0|-|-",
+            "active": true,
+            "prefix": "2001:db9:859::/48",
+            "asns_inf": [2, 3, 7],
+            "hijack_as": 203,
+            "peers_seen": [7],
+            "num_asns_inf": 3,
+            "num_peers_seen": 1,
+            "configured_prefix": "2001:db9::/48"
+        }
     }
 ]


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->

What component(s) does this PR affect?

- [X] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #597 

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->

### Type
<!--- What types of changes does your code introduce? -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [X] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation.
- [ ] I have updated the documentation accordingly.
