### PR TITLE
Remove process parallelism from re-configuration task

### DIFF
--- a/backend-services/configuration/core/configuration.py
+++ b/backend-services/configuration/core/configuration.py
@@ -1270,11 +1270,14 @@ def configure_configuration(msg, shared_memory_manager_dict):
                             if service not in services_to_notify:
                                 services_to_notify.append(service)
 
-                    # configure needed services with the new config in background process
-                    mp.Process(
-                        target=post_configuration_to_other_services,
-                        args=(shared_memory_manager_dict, services_to_notify),
-                    ).start()
+                    # configure needed services with the new config in current process
+                    post_configuration_to_other_services(
+                        shared_memory_manager_dict, services=services_to_notify
+                    )
+                    # mp.Process(
+                    #     target=post_configuration_to_other_services,
+                    #     args=(shared_memory_manager_dict, services_to_notify),
+                    # ).start()
 
                     # if the change did not come from the file observer itself,
                     # we write the file


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->

What component(s) does this PR affect?

- [X] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #622 

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->

### Type
<!--- What types of changes does your code introduce? -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [X] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation.
- [ ] I have updated the documentation accordingly.
