### PR TITLE
fix: expired keys and pip upgrade

### DIFF
--- a/backend-services/autoignore/Dockerfile
+++ b/backend-services/autoignore/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /root
 RUN ln -s /usr/local/lib/pyenv/versions/3.6.8/bin/python /usr/local/bin
 
 COPY requirements.txt ./requirements.txt
+RUN pip install --upgrade pip
 RUN pip --no-cache-dir install -r requirements.txt --ignore-installed
 
 RUN mkdir -p /etc/artemis/ && \

--- a/backend-services/autostarter/Dockerfile
+++ b/backend-services/autostarter/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /root
 RUN ln -s /usr/local/lib/pyenv/versions/3.6.8/bin/python /usr/local/bin
 
 COPY requirements.txt ./requirements.txt
+RUN pip install --upgrade pip
 RUN pip --no-cache-dir install -r requirements.txt --ignore-installed
 
 RUN mkdir -p /etc/artemis/ && \

--- a/backend-services/configuration/Dockerfile
+++ b/backend-services/configuration/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /root
 RUN ln -s /usr/local/lib/pyenv/versions/3.6.8/bin/python /usr/local/bin
 
 COPY requirements.txt ./requirements.txt
+RUN pip install --upgrade pip
 RUN pip --no-cache-dir install -r requirements.txt --ignore-installed
 
 RUN mkdir -p /etc/artemis/ && \

--- a/backend-services/database/Dockerfile
+++ b/backend-services/database/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /root
 RUN ln -s /usr/local/lib/pyenv/versions/3.6.8/bin/python /usr/local/bin
 
 COPY requirements.txt ./requirements.txt
+RUN pip install --upgrade pip
 RUN pip --no-cache-dir install -r requirements.txt --ignore-installed
 
 RUN mkdir -p /etc/artemis/ && \

--- a/backend-services/detection/Dockerfile
+++ b/backend-services/detection/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /root
 RUN ln -s /usr/local/lib/pyenv/versions/3.6.8/bin/python /usr/local/bin
 
 COPY requirements.txt ./requirements.txt
+RUN pip install --upgrade pip
 RUN pip --no-cache-dir install -r requirements.txt --ignore-installed
 
 RUN mkdir -p /etc/artemis/ && \

--- a/backend-services/fileobserver/Dockerfile
+++ b/backend-services/fileobserver/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /root
 RUN ln -s /usr/local/lib/pyenv/versions/3.6.8/bin/python /usr/local/bin
 
 COPY requirements.txt ./requirements.txt
+RUN pip install --upgrade pip
 RUN pip --no-cache-dir install -r requirements.txt --ignore-installed
 
 RUN mkdir -p /etc/artemis/ && \

--- a/backend-services/mitigation/Dockerfile
+++ b/backend-services/mitigation/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /root
 RUN ln -s /usr/local/lib/pyenv/versions/3.6.8/bin/python /usr/local/bin
 
 COPY requirements.txt ./requirements.txt
+RUN pip install --upgrade pip
 RUN pip --no-cache-dir install -r requirements.txt --ignore-installed
 
 RUN mkdir -p /etc/artemis/ && \

--- a/backend-services/notifier/Dockerfile
+++ b/backend-services/notifier/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /root
 RUN ln -s /usr/local/lib/pyenv/versions/3.6.8/bin/python /usr/local/bin
 
 COPY requirements.txt ./requirements.txt
+RUN pip install --upgrade pip
 RUN pip --no-cache-dir install -r requirements.txt --ignore-installed
 
 RUN mkdir -p /etc/artemis/ && \

--- a/backend-services/prefixtree/Dockerfile
+++ b/backend-services/prefixtree/Dockerfile
@@ -7,6 +7,8 @@ WORKDIR /root
 RUN ln -s /usr/local/lib/pyenv/versions/3.6.8/bin/python /usr/local/bin
 
 COPY requirements.txt ./requirements.txt
+
+RUN pip install --upgrade pip
 RUN pip --no-cache-dir install -r requirements.txt --ignore-installed
 
 RUN mkdir -p /etc/artemis/ && \

--- a/monitor-services/bgpstreamhisttap/Dockerfile
+++ b/monitor-services/bgpstreamhisttap/Dockerfile
@@ -1,7 +1,7 @@
 FROM mavromat/artemis-base-images:monitor-1.0.3
 LABEL maintainer="Dimitrios Mavrommatis <jim.mavrommatis@gmail.com>"
 
-RUN apt-get update && \
+RUN apt-get update --allow-insecure-repositories && \
     apt-get -y install --no-install-recommends python3-pip libpq-dev git && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -9,8 +9,8 @@ RUN apt-get update && \
 WORKDIR /root
 
 COPY requirements.txt ./requirements.txt
-RUN pip3 --no-cache-dir install -r requirements.txt
 
+RUN pip3 --no-cache-dir install -r requirements.txt
 RUN mkdir -p /etc/artemis/ && \
     mkdir -p /var/log/artemis/
 

--- a/monitor-services/bgpstreamkafkatap/Dockerfile
+++ b/monitor-services/bgpstreamkafkatap/Dockerfile
@@ -1,7 +1,7 @@
 FROM mavromat/artemis-base-images:monitor-1.0.3
 LABEL maintainer="Dimitrios Mavrommatis <jim.mavrommatis@gmail.com>"
 
-RUN apt-get update && \
+RUN apt-get update --allow-insecure-repositories && \
     apt-get -y install --no-install-recommends python3-pip libpq-dev git && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -9,8 +9,8 @@ RUN apt-get update && \
 WORKDIR /root
 
 COPY requirements.txt ./requirements.txt
+RUN pip3 install --upgrade pip
 RUN pip3 --no-cache-dir install -r requirements.txt
-
 RUN mkdir -p /etc/artemis/ && \
     mkdir -p /var/log/artemis/
 

--- a/monitor-services/bgpstreamlivetap/Dockerfile
+++ b/monitor-services/bgpstreamlivetap/Dockerfile
@@ -1,7 +1,7 @@
 FROM mavromat/artemis-base-images:monitor-1.0.3
 LABEL maintainer="Dimitrios Mavrommatis <jim.mavrommatis@gmail.com>"
 
-RUN apt-get update && \
+RUN apt-get update --allow-insecure-repositories && \
     apt-get -y install --no-install-recommends python3-pip libpq-dev git && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -9,8 +9,8 @@ RUN apt-get update && \
 WORKDIR /root
 
 COPY requirements.txt ./requirements.txt
+RUN pip3 install --upgrade pip
 RUN pip3 --no-cache-dir install -r requirements.txt
-
 RUN mkdir -p /etc/artemis/ && \
     mkdir -p /var/log/artemis/
 

--- a/monitor-services/exabgptap/Dockerfile
+++ b/monitor-services/exabgptap/Dockerfile
@@ -1,7 +1,7 @@
 FROM mavromat/artemis-base-images:monitor-1.0.3
 LABEL maintainer="Dimitrios Mavrommatis <jim.mavrommatis@gmail.com>"
 
-RUN apt-get update && \
+RUN apt-get update --allow-insecure-repositories && \
     apt-get -y install --no-install-recommends python3-pip libpq-dev git && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -9,8 +9,8 @@ RUN apt-get update && \
 WORKDIR /root
 
 COPY requirements.txt ./requirements.txt
+RUN pip3 install --upgrade pip
 RUN pip3 --no-cache-dir install -r requirements.txt
-
 RUN mkdir -p /etc/artemis/ && \
     mkdir -p /var/log/artemis/
 

--- a/monitor-services/riperistap/Dockerfile
+++ b/monitor-services/riperistap/Dockerfile
@@ -1,7 +1,7 @@
 FROM mavromat/artemis-base-images:monitor-1.0.3
 LABEL maintainer="Dimitrios Mavrommatis <jim.mavrommatis@gmail.com>"
 
-RUN apt-get update && \
+RUN apt-get update --allow-insecure-repositories && \
     apt-get -y install --no-install-recommends python3-pip libpq-dev git && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -9,8 +9,8 @@ RUN apt-get update && \
 WORKDIR /root
 
 COPY requirements.txt ./requirements.txt
+RUN pip3 install --upgrade pip
 RUN pip3 --no-cache-dir install -r requirements.txt
-
 RUN mkdir -p /etc/artemis/ && \
     mkdir -p /var/log/artemis/
 


### PR DESCRIPTION
<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
<!-- Describe your changes in detail -->
Fixing error occurring when building monitor and backend images

What component(s) does this PR affect?

- [x] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:

- [ ] Back-End (Database, Detection/Configuration/etc. Microservices)
- [ ] Front-End (Flask, API, UI, etc)
- [ ] Monitor (RIPE RIS, BGPStream RV/RIS/CAIDA, etc.)
- [ ] Docs
- [ ] Build System

<!-- [Optional] Please elaborate on the component(s) requiring changes here: -->

### Related Issue
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- If you are suggesting a new feature or change, please discuss it in an issue first -->
<!-- If you are fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please don't forget to add `(close/fix #<issue-no>)` to the pull request title -->

<!-- Please link to the issue here: -->
Resolves #

### Solution
<!-- How is this issue solved/fixed? What is the main design/logic? -->

### Type
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs update
- [ ] None of the above

<!-- [Optional] If none of the above applies, please elaborate here -->

### Checklist:
<!-- Go over all the following points, and mark what applies. -->
- [ ] I have read the **[contributing guide](https://github.com/FORTH-ICS-INSPIRE/artemis/blob/master/CONTRIBUTING.md)** and my code conforms to the guidelines.
- [ ] This change requires a change in the documentation.
- [ ] I have updated the documentation accordingly.
