### PR TITLE
update compose dns routine to use dnspython.

### DIFF
--- a/utils/artemis_utils/service.py
+++ b/utils/artemis_utils/service.py
@@ -19,7 +19,7 @@ def get_local_ip():
 def resolve_dns(query:str, rtype = ['AAAA','A'], timeout:int = 2)->list:
   if isinstance(rtype, str):
     rtype.upper()
-    rlist =  rtype.split()
+    rlist = rtype.split()
   else:
     rlist = (t.upper() for t in rtype)
 

--- a/utils/artemis_utils/service.py
+++ b/utils/artemis_utils/service.py
@@ -21,7 +21,7 @@ def resolve_dns(query:str, rtype = ['AAAA','A'], timeout:int = 2)->list:
     rtype.upper()
     rlist = rtype.split()
   else:
-    rlist = (t.upper() for t in rtype)
+    rlist = [t.upper() for t in rtype]
 
   def lookup(query, rtype:str, timeout:int = 2)->list:
     resolver = dns.resolver.Resolver()

--- a/utils/artemis_utils/service.py
+++ b/utils/artemis_utils/service.py
@@ -3,6 +3,7 @@ import re
 import socket
 import time
 import dns.resolver
+import dns.query
 
 import requests
 from artemis_utils.constants import HEALTH_CHECK_TIMEOUT

--- a/utils/setup.py
+++ b/utils/setup.py
@@ -32,5 +32,6 @@ setuptools.setup(
         "psycopg2==2.8.4",
         "slacker-log-handler==1.7.1",
         "tornado==6.0.4",
+        "dnspython==2.2.1",
     ],
 )


### PR DESCRIPTION
update compose dns routine to use dnspython. gethostbyaddr and gethostbyname only return single responses on alpine/musl. Fix for podman

<!-- Thanks for issuing a Pull Request (PR)! -->

### Description of PR
Update service_to_ips_and_replicas_in_compose to use dnspython instead of gethostbyaddr and gethostbyname. Alpine uses musl which only returns a single answer. Returning a single answer to a DNS PTR record prevents the solution running on podman as podman inserts multuple PTR values (container id, instance name, service name)

What component(s) does this PR affect?

- [x] Back-End (Database, Detection/Configuration/etc. Microservices) *Utils

<!-- [Optional] Please elaborate on the affected component(s) here: -->

Does the PR require changes on other components? If yes, please mark the components:
PR required dnspython to be a dependency for utils package. 


<!-- Please link to the issue here: -->
Resolves #
#672

### Solution
use dnspython to complete dns lookups instead of socket.gethostbyaddr

### Type
bugfix

